### PR TITLE
Make Collector return type more explicit

### DIFF
--- a/src/PHPStan/Collector/ContextFromReturnedArrayWithTemplateAttributeCollector.php
+++ b/src/PHPStan/Collector/ContextFromReturnedArrayWithTemplateAttributeCollector.php
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\Annotation\Route as LegacyRoute;
 use Symfony\Component\Routing\Attribute\Route;
 
 /**
- * @implements Collector<MethodReturnStatementsNode, list<array{
+ * @implements Collector<MethodReturnStatementsNode, non-empty-list<array{
  *     startLine: int,
  *     endLine: int,
  *     template: string,


### PR DESCRIPTION
while the previous return type was correct, it did not explicitly state/protect you from someone changing the collector and make it return a empty array.

thats a major problem which can happen, and I want to make sure this error will not bite you, like it did in my projects.

for in-detail context see https://github.com/phpstan/phpstan/discussions/11701#discussioncomment-10660711