### PR TITLE
Remove unused import and update CS fixer config

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -22,6 +22,7 @@ return (new Config())
             'type_declaration_spaces' => true,
             'types_spaces' => ['space' => 'single'],
             'unary_operator_spaces' => true,
+            'no_unused_imports' => true,
         ],
     )
     ->setFinder($finder);

--- a/src/Twig/TwigFactory.php
+++ b/src/Twig/TwigFactory.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace TwigStan\Twig;
 
 use InvalidArgumentException;
-use Symfony\Bundle\WebProfilerBundle\Twig\WebProfilerExtension;
 use Twig\Environment;
 use Twig\Extension\EscaperExtension;
 use Twig\Loader\ArrayLoader;


### PR DESCRIPTION
Added `no_unused_imports` rule to the PHP CS Fixer configuration.