### PR TITLE
Fix TwigFileNormalizer

### DIFF
--- a/src/Processing/ScopeInjection/TwigScopeInjector.php
+++ b/src/Processing/ScopeInjection/TwigScopeInjector.php
@@ -84,8 +84,9 @@ final readonly class TwigScopeInjector
             if (is_a($data->collecterType, TemplateContextCollector::class, true)) {
                 foreach ($data->data as $renderData) {
                     $template = $this->twigFileNormalizer->normalize($renderData['template']);
+                    $templatePath = $this->twigFileNormalizer->toAbsolute($template);
 
-                    $templateRenderContexts[$template][] = $renderData['context'];
+                    $templateRenderContexts[$templatePath][] = $renderData['context'];
                 }
             }
         }
@@ -134,7 +135,7 @@ final readonly class TwigScopeInjector
                 $this->phpParser->parseFile($flatteningResult->phpFile),
                 new NameResolver(),
                 new InjectContextVisitor(
-                    $templateRenderContext[$flatteningResult->twigFileName] ?? new ArrayShapeNode([]),
+                    $templateRenderContext[$flatteningResult->twigFilePath] ?? new ArrayShapeNode([]),
                     $contextBeforeBlockRelatedToTemplate,
                     $this->arrayShapeMerger,
                 ),

--- a/src/Twig/TwigFileNormalizer.php
+++ b/src/Twig/TwigFileNormalizer.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace TwigStan\Twig;
 
-use Symfony\Component\Filesystem\Path;
 use Twig\Environment;
 use TwigStan\Twig\Loader\AbsolutePathLoader;
 
@@ -16,19 +15,24 @@ final readonly class TwigFileNormalizer
 
     public function normalize(string $twigFileName): string
     {
+        if (str_starts_with($twigFileName, '$')) {
+            return $twigFileName;
+        }
+
         if (str_starts_with($twigFileName, '@')) {
             return $twigFileName;
         }
 
-        if (Path::isAbsolute($twigFileName)) {
-            /**
-             * @var AbsolutePathLoader $loader
-             */
-            $loader = $this->twig->getLoader();
+        /**
+         * @var AbsolutePathLoader $loader
+         */
+        $loader = $this->twig->getLoader();
 
-            return $loader->maybeResolveAbsolutePath($twigFileName);
-        }
+        return $loader->maybeResolveAbsolutePath($twigFileName);
+    }
 
-        return sprintf('@%s', $twigFileName);
+    public function toAbsolute(string $twigFileName): string
+    {
+        return $this->twig->getLoader()->getSourceContext($twigFileName)->getPath();
     }
 }

--- a/tests/EndToEnd/RenderPoints/RenderFromAbstractController.php
+++ b/tests/EndToEnd/RenderPoints/RenderFromAbstractController.php
@@ -13,7 +13,7 @@ class RenderFromAbstractController extends AbstractController
     {
         $response = new Response(status: Response::HTTP_CREATED);
 
-        return $this->render('EndToEnd/RenderPoints/render.html.twig', [
+        return $this->render('RenderPoints/render.html.twig', [
             'title' => 'RenderAction',
             'artists' => ['Adele', 'Kanye West'],
         ], $response);
@@ -21,7 +21,7 @@ class RenderFromAbstractController extends AbstractController
 
     public function renderViewAction(): Response
     {
-        return new Response($this->renderView('EndToEnd/RenderPoints/render.html.twig', [
+        return new Response($this->renderView('RenderPoints/render.html.twig', [
             'title' => 'RenderViewAction',
             'artists' => ['Adele', 'Kanye West'],
         ]));

--- a/tests/EndToEnd/RenderPoints/RenderFromTwig.php
+++ b/tests/EndToEnd/RenderPoints/RenderFromTwig.php
@@ -10,7 +10,7 @@ class RenderFromTwig
 {
     public function generateContent(Environment $environment): string
     {
-        return $environment->render('EndToEnd/RenderPoints/render.html.twig', [
+        return $environment->render('RenderPoints/render.html.twig', [
             'title' => 'RenderAction',
             'artists' => ['Adele', 'Kanye West'],
         ]);

--- a/tests/twig-loader.php
+++ b/tests/twig-loader.php
@@ -7,6 +7,7 @@ use Twig\Loader\FilesystemLoader;
 
 $loader = new FilesystemLoader([], __DIR__);
 
+$loader->addPath(__DIR__ . '/EndToEnd'); // __main__
 $loader->addPath(__DIR__ . '/EndToEnd', 'EndToEnd');
 
 return new Environment($loader);


### PR DESCRIPTION
Hi @ruudk 

the fix https://github.com/twigstan/twigstan/pull/17/commits/e9569209fd9ee50a02f21ba93d8b2b323d11e288 breaks on my project, the main namespace wasn't resolved correctly.

The error we got in tests was expected since there was no `__main__` namespace in tests. I added one.
Then, I have a conflict between the main and the EndToEnd one.
Twigstan was playing with twig filename and consider differents `@__main__/Foo` and `@EndToEnd/Foo`.

In order to solve this I used the filePath instead of the fileName as array key.

Works fine on my project.