### PR TITLE
Fix FilesFinder find method with no path are provided.

### DIFF
--- a/src/Finder/FilesFinder.php
+++ b/src/Finder/FilesFinder.php
@@ -22,6 +22,10 @@ final class FilesFinder
      */
     public function find(): array
     {
+        if ($this->paths === []) {
+            return [];
+        }
+
         $finder = Finder::create()
             ->files()
             ->name([$this->namePattern])

--- a/tests/Finder/FilesFinderTest.php
+++ b/tests/Finder/FilesFinderTest.php
@@ -43,4 +43,17 @@ final class FilesFinderTest extends TestCase
             __DIR__ . '/files/template.twig',
         ], array_keys($files));
     }
+
+    public function testFindWithNoPaths(): void
+    {
+        $finder = new FilesFinder(
+            '*.twig',
+            [],
+            [],
+        );
+
+        $files = $finder->find();
+
+        self::assertSame([], array_keys($files));
+    }
 }


### PR DESCRIPTION
Added a check in FilesFinder to return an empty array if no paths are given, avoiding exception at runtime.

Updated the test suite to include a case for this scenario to ensure correct functionality.