### PR TITLE
Fix `is defined` conditions

### DIFF
--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -21,7 +21,7 @@ services:
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 	-
-		class: TwigStan\PHPStan\TypeSpecifying\VarTypeSpecifyingExtension
+		class: TwigStan\PHPStan\DynamicReturnType\TypeHintReturnType
 		tags:
 			- phpstan.broker.dynamicFunctionReturnTypeExtension
 	-

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -29,6 +29,10 @@ services:
 		tags:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
 	-
+		class: TwigStan\PHPStan\TypeSpecifying\VariableExistsExtension
+		tags:
+			- phpstan.typeSpecifier.functionTypeSpecifyingExtension
+	-
 		class: TwigStan\PHPStan\Collector\BlockContextCollector
 		tags:
 			- phpstan.collector

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,11 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Creating new PHPStan\\\\Node\\\\IssetExpr is not covered by backward compatibility promise\\. The class might change in a minor PHPStan version\\.$#"
+			count: 1
+			path: src/PHPStan/TypeSpecifying/VariableExistsExtension.php
+
+		-
 			message: "#^Method TwigStan\\\\Twig\\\\Node\\\\NodeFinder\\:\\:findInstanceOf\\(\\) should return Twig\\\\Node\\\\Node\\|null but returns class\\-string\\<Twig\\\\Node\\\\Node\\>\\|Twig\\\\Node\\\\Node\\.$#"
 			count: 1
 			path: src/Twig/Node/NodeFinder.php

--- a/src/PHPStan/DynamicReturnType/TypeHintReturnType.php
+++ b/src/PHPStan/DynamicReturnType/TypeHintReturnType.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace TwigStan\PHPStan\TypeSpecifying;
+namespace TwigStan\PHPStan\DynamicReturnType;
 
 use PhpParser\Node\Expr\FuncCall;
 use PhpParser\Node\Scalar\String_;
@@ -18,7 +18,7 @@ use PHPStan\Type\DynamicFunctionReturnTypeExtension;
 use PHPStan\Type\ErrorType;
 use PHPStan\Type\Type;
 
-final readonly class VarTypeSpecifyingExtension implements DynamicFunctionReturnTypeExtension
+final readonly class TypeHintReturnType implements DynamicFunctionReturnTypeExtension
 {
     public function __construct(
         private PhpDocParser $phpDocParser,

--- a/src/PHPStan/TypeSpecifying/VariableExistsExtension.php
+++ b/src/PHPStan/TypeSpecifying/VariableExistsExtension.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\PHPStan\TypeSpecifying;
+
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Analyser\SpecifiedTypes;
+use PHPStan\Analyser\TypeSpecifier;
+use PHPStan\Analyser\TypeSpecifierAwareExtension;
+use PHPStan\Analyser\TypeSpecifierContext;
+use PHPStan\Node\IssetExpr;
+use PHPStan\Reflection\FunctionReflection;
+use PHPStan\ShouldNotHappenException;
+use PHPStan\Type\FunctionTypeSpecifyingExtension;
+
+final class VariableExistsExtension implements FunctionTypeSpecifyingExtension, TypeSpecifierAwareExtension
+{
+    private TypeSpecifier $typeSpecifier;
+
+    public function setTypeSpecifier(TypeSpecifier $typeSpecifier): void
+    {
+        $this->typeSpecifier = $typeSpecifier;
+    }
+
+    public function isFunctionSupported(
+        FunctionReflection $functionReflection,
+        FuncCall $node,
+        TypeSpecifierContext $context,
+    ): bool {
+        return $functionReflection->getName() === 'twigstan_variable_exists' && !$context->null();
+    }
+
+    public function specifyTypes(
+        FunctionReflection $functionReflection,
+        FuncCall $node,
+        Scope $scope,
+        TypeSpecifierContext $context,
+    ): SpecifiedTypes {
+        if (!isset($node->getArgs()[0])) {
+            return new SpecifiedTypes();
+        }
+
+        if ($context->null()) {
+            throw new ShouldNotHappenException();
+        }
+
+        if (!$node->getArgs()[0]->value instanceof String_) {
+            return new SpecifiedTypes();
+        }
+
+        $variableName = $node->getArgs()[0]->value->value;
+        $variable = new Variable($variableName);
+        $variableType = $scope->getType($variable);
+
+        if ($context->false()) {
+            return $this->typeSpecifier->create(
+                new IssetExpr($variable),
+                $variableType,
+                $context,
+            );
+        }
+
+        return $this->typeSpecifier->create(
+            $variable,
+            $variableType,
+            $context,
+        );
+    }
+
+}

--- a/src/Processing/Compilation/TwigVisitor/SimpleNameExpression.php
+++ b/src/Processing/Compilation/TwigVisitor/SimpleNameExpression.php
@@ -35,8 +35,8 @@ final class SimpleNameExpression extends NameExpression
                 $compiler->repr(true);
             } else {
                 $compiler
-                    ->raw('isset($')
-                    ->raw($name)
+                    ->raw('twigstan_variable_exists(')
+                    ->string($name)
                     ->raw(')')
                 ;
             }

--- a/stubs/functions.php
+++ b/stubs/functions.php
@@ -1,3 +1,5 @@
 <?php
 
 function twigstan_type_hint(string $type) {}
+
+function twigstan_variable_exists(string $name): bool {}

--- a/tests/EndToEnd/RenderPoints/optionality.html.twig
+++ b/tests/EndToEnd/RenderPoints/optionality.html.twig
@@ -1,5 +1,8 @@
 {% assert_variable_exists name maybe %}
+{% assert_type name 'string|null' %}
 
 {% if name is defined %}
+    {% assert_variable_exists name yes %}
+    {% assert_type name 'string|null' %}
     {{ name }}
 {% endif %}

--- a/tests/EndToEnd/Types/is_defined.twig
+++ b/tests/EndToEnd/Types/is_defined.twig
@@ -1,0 +1,33 @@
+{% types {
+    name?: 'string|null',
+} %}
+
+{% assert_variable_exists name maybe %}
+{% assert_type name 'string|null' %}
+
+{% if not name is defined %}
+    {% assert_variable_exists name no %}
+    {% assert_type name '*ERROR*' %}
+{% else %}
+    {% assert_variable_exists name yes %}
+    {% assert_type name 'string|null' %}
+    {{ name }}
+{% endif %}
+
+{% if name is defined %}
+    {% assert_variable_exists name yes %}
+    {% assert_type name 'string|null' %}
+    {{ name }}
+{% else %}
+    {% assert_variable_exists name no %}
+    {% assert_type name '*ERROR*' %}
+{% endif %}
+
+ {% if name is defined and name is not null %}
+     {% assert_variable_exists name yes %}
+     {% assert_type name 'string' %}
+     {{ name }}
+ {% else %}
+     {% assert_variable_exists name maybe %}
+     {% assert_type name 'string|null' %}
+ {% endif %}


### PR DESCRIPTION
The previous implementation to check if a variable exists was flawed.

This is now solved with a VariableExistsExtension.
