### PR TITLE
Remove `twigstan` configuration level

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,6 @@ indent_size = 4
 [*.neon]
 indent_style = tab
 
+[twigstan.neon.dist]
+indent_style = tab
+

--- a/config/application.neon
+++ b/config/application.neon
@@ -1,55 +1,54 @@
 parameters:
-	twigstan:
-		php:
-			paths: []
-			excludes: []
-		twig:
-			paths: []
-			excludes: []
-		ignoreErrors:
-			-
-				identifier: isset.variable
+	php:
+		paths: []
+		excludes: []
+	twig:
+		paths: []
+		excludes: []
+	ignoreErrors:
+		-
+			identifier: isset.variable
 
-			-
-				# It's perfectly fine to do `a == b ? 'yes' : 'no'` in Twig.
-				identifier: equal.notAllowed
+		-
+			# It's perfectly fine to do `a == b ? 'yes' : 'no'` in Twig.
+			identifier: equal.notAllowed
 
-			-
-				# It's perfectly fine to do `a != b ? 'no' : 'yes'` in Twig.
-				identifier: notEqual.notAllowed
+		-
+			# It's perfectly fine to do `a != b ? 'no' : 'yes'` in Twig.
+			identifier: notEqual.notAllowed
 
-			-
-				# The context is backed up before a loop and restored after it.
-				# Therefore this is a non-issue in Twig templates.
-				identifier: foreach.valueOverwrite
+		-
+			# The context is backed up before a loop and restored after it.
+			# Therefore this is a non-issue in Twig templates.
+			identifier: foreach.valueOverwrite
 
-			-
-				# When an array inside the context is not typed, this produces an error.
-				message: '#__twigstan_context#'
-				identifier: missingType.iterableValue
+		-
+			# When an array inside the context is not typed, this produces an error.
+			message: '#__twigstan_context#'
+			identifier: missingType.iterableValue
 
-			-
-				# When the variable that is passed does not exist, this produces an error.
-				message: '#CoreExtension::ensureTraversable#'
-				identifier: argument.templateType
+		-
+			# When the variable that is passed does not exist, this produces an error.
+			message: '#CoreExtension::ensureTraversable#'
+			identifier: argument.templateType
 services:
 	-
 		class: Twig\Environment
 		factory: @TwigStan\Twig\TwigFactory::create
 	- Symfony\Component\Filesystem\Filesystem
 	- TwigStan\Application\AnalyzeCommand(
-		environmentLoader: %twigstan.environmentLoader%
+		environmentLoader: %environmentLoader%
 		tempDirectory: %tmpDir%
 		currentWorkingDirectory: %currentWorkingDirectory%
 		phpFilesFinder: TwigStan\Finder\FilesFinder(
 			namePattern: *.php
-			paths: %twigstan.php.paths%
-			exclusions: %twigstan.php.excludes%
+			paths: %php.paths%
+			exclusions: %php.excludes%
 		)
 		twigFilesFinder: TwigStan\Finder\FilesFinder(
 			namePattern: *.twig
-			paths: %twigstan.twig.paths%
-			exclusions: %twigstan.twig.excludes%
+			paths: %twig.paths%
+			exclusions: %twig.excludes%
 		)
 		givenFilesFinder: TwigStan\Finder\GivenFilesFinder(
 			currentWorkingDirectory: %currentWorkingDirectory%
@@ -61,7 +60,7 @@ services:
 	- TwigStan\PHPStan\Analysis\AnalysisResultFromJsonReader
 	- TwigStan\PHPStan\Analysis\ErrorCollapser
 	- TwigStan\PHPStan\Analysis\ErrorFilter(
-		ignoreErrors: %twigstan.ignoreErrors%
+		ignoreErrors: %ignoreErrors%
 	)
 	- TwigStan\PHPStan\Analysis\ErrorToSourceFileMapper
 	- TwigStan\PHPStan\Analysis\ErrorTransformer
@@ -85,5 +84,5 @@ services:
 	- TwigStan\Twig\TokenParser\AssertTypeTokenParser
 	- TwigStan\Twig\TokenParser\AssertVariableExistsTokenParser
 	- TwigStan\Twig\TokenParser\DumpTypeTokenParser
-	- TwigStan\Twig\TwigFactory(environmentLoader: %twigstan.environmentLoader%)
+	- TwigStan\Twig\TwigFactory(environmentLoader: %environmentLoader%)
 	- TwigStan\Twig\TwigFileCanonicalizer

--- a/src/DependencyInjection/SchemaFactory.php
+++ b/src/DependencyInjection/SchemaFactory.php
@@ -24,39 +24,37 @@ final readonly class SchemaFactory
             ),
             'services' => Expect::array(),
             'parameters' => Expect::structure([
-                'twigstan' => Expect::structure([
-                    'php' => Expect::structure([
-                        'paths' => Expect::listOf('string')->transform(
-                            fn(array $directories) => array_map(
-                                fn(string $path) => Path::makeAbsolute($path, $basePath),
-                                $directories,
-                            ),
+                'php' => Expect::structure([
+                    'paths' => Expect::listOf('string')->transform(
+                        fn(array $directories) => array_map(
+                            fn(string $path) => Path::makeAbsolute($path, $basePath),
+                            $directories,
                         ),
-                        'excludes' => Expect::listOf('string'),
-                    ])->castTo('array'),
-                    'twig' => Expect::structure([
-                        'paths' => Expect::listOf('string')->transform(
-                            fn(array $directories) => array_map(
-                                fn(string $path) => Path::makeAbsolute($path, $basePath),
-                                $directories,
-                            ),
-                        ),
-                        'excludes' => Expect::listOf('string'),
-                    ])->castTo('array'),
-                    'environmentLoader' => Expect::string()->transform(
-                        fn(string $path) => Path::makeAbsolute($path, $basePath),
                     ),
-                    'ignoreErrors' => Expect::listOf(Expect::structure([
-                        'message' => Expect::anyOf(Expect::string(), Expect::null()),
-                        'identifier' => Expect::anyOf(Expect::string(), Expect::null()),
-                        'path' => Expect::anyOf(
-                            Expect::string()->transform(
-                                fn(string $path) => str_contains($path, '*') ? $path : Path::makeAbsolute($path, $basePath),
-                            ),
-                            Expect::null(),
-                        ),
-                    ])->castTo(IgnoreError::class)),
+                    'excludes' => Expect::listOf('string'),
                 ])->castTo('array'),
+                'twig' => Expect::structure([
+                    'paths' => Expect::listOf('string')->transform(
+                        fn(array $directories) => array_map(
+                            fn(string $path) => Path::makeAbsolute($path, $basePath),
+                            $directories,
+                        ),
+                    ),
+                    'excludes' => Expect::listOf('string'),
+                ])->castTo('array'),
+                'environmentLoader' => Expect::string()->transform(
+                    fn(string $path) => Path::makeAbsolute($path, $basePath),
+                ),
+                'ignoreErrors' => Expect::listOf(Expect::structure([
+                    'message' => Expect::anyOf(Expect::string(), Expect::null()),
+                    'identifier' => Expect::anyOf(Expect::string(), Expect::null()),
+                    'path' => Expect::anyOf(
+                        Expect::string()->transform(
+                            fn(string $path) => str_contains($path, '*') ? $path : Path::makeAbsolute($path, $basePath),
+                        ),
+                        Expect::null(),
+                    ),
+                ])->castTo(IgnoreError::class)),
             ])->castTo('array'),
         ])->castTo('array');
     }

--- a/tests/twigstan.neon
+++ b/tests/twigstan.neon
@@ -1,9 +1,8 @@
 parameters:
-	twigstan:
-		twig:
-			paths: []
-			excludes: []
-		php:
-			paths: []
-			excludes: []
-		environmentLoader: twig-loader.php
+	twig:
+		paths: []
+		excludes: []
+	php:
+		paths: []
+		excludes: []
+	environmentLoader: twig-loader.php

--- a/twigstan.neon.dist
+++ b/twigstan.neon.dist
@@ -1,42 +1,41 @@
 parameters:
-    twigstan:
-        # TwigStan needs access to your Twig environment to analyze your templates.
-        environmentLoader: twig-loader.php
+	# TwigStan needs access to your Twig environment to analyze your templates.
+	environmentLoader: twig-loader.php
 
-        # Used to scan for PHP controllers that render Twig templates
-        php:
-            paths:
-                - src/Controller
+	# Used to scan for PHP controllers that render Twig templates
+	php:
+		paths:
+			- src/Controller
 
-            # If you want to exclude certain directories/files from scanning, you can define them below.
-            # You can use * as a wildcard.
-            excludes: []
+		# If you want to exclude certain directories/files from scanning, you can define them below.
+		# You can use * as a wildcard.
+		excludes: []
 
-        # Used to scan for Twig templates
-        twig:
-            paths:
-                - templates
+	# Used to scan for Twig templates
+	twig:
+		paths:
+			- templates
 
-            # If you want to exclude certain directories/files from scanning, you can define them below.
-            # You can use * as a wildcard.
-            excludes: []
+		# If you want to exclude certain directories/files from scanning, you can define them below.
+		# You can use * as a wildcard.
+		excludes: []
 
-        ignoreErrors: []
-        #
-        # If you want to ignore a single message, you can define a pattern like this:
-        #    -
-        #        message: '#Some error pattern#'
-        #
-        # Or ignore a specific identifier:
-        #    -
-        #        identifier: 'some.identifier'
-        #
-        # Or ignore errors in a specific path. This can be a full path or a wildcard:
-        #    -
-        #        path: 'templates/somewhere/*.html.twig'
-        #
-        # Or combine them:
-        #    -
-        #        message: '#Some error pattern#'
-        #        identifier: 'some.identifier'
-        #        path: 'templates/somewhere/*.html.twig'
+	ignoreErrors: []
+	#
+	# If you want to ignore a single message, you can define a pattern like this:
+	#	-
+	#		message: '#Some error pattern#'
+	#
+	# Or ignore a specific identifier:
+	#	-
+	#		identifier: 'some.identifier'
+	#
+	# Or ignore errors in a specific path. This can be a full path or a wildcard:
+	#	-
+	#		path: 'templates/somewhere/*.html.twig'
+	#
+	# Or combine them:
+	#	-
+	#		message: '#Some error pattern#'
+	#		identifier: 'some.identifier'
+	#		path: 'templates/somewhere/*.html.twig'


### PR DESCRIPTION
The configuration is for TwigStan only. So there is no point in having a `twigstan` level.

Before, this ran as a PHPStan Extension. There it made sense.
