### PR TITLE
Add `phpstan.configurationFile` and `phpstan.memoryLimit` options

### DIFF
--- a/config/application.neon
+++ b/config/application.neon
@@ -1,4 +1,6 @@
 parameters:
+	phpstan:
+		configurationFile: phpstan.neon
 	php:
 		paths: []
 		excludes: []
@@ -54,7 +56,11 @@ services:
 			currentWorkingDirectory: %currentWorkingDirectory%
 		)
 	)
-	- TwigStan\Application\PHPStanRunner(currentWorkingDirectory: %currentWorkingDirectory%)
+	- TwigStan\Application\PHPStanRunner(
+		phpstanConfigurationFile: %phpstan.configurationFile%
+		phpstanMemoryLimit: %phpstan.memoryLimit%
+		currentWorkingDirectory: %currentWorkingDirectory%
+	)
 	- TwigStan\PHP\PrettyPrinter
 	- TwigStan\PHP\StrictPhpParser
 	- TwigStan\PHPStan\Analysis\AnalysisResultFromJsonReader

--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -1,5 +1,3 @@
-includes:
-	- phar://phpstan.phar/conf/bleedingEdge.neon
 parameters:
 	reportUnmatchedIgnoredErrors: false
 	treatPhpDocTypesAsCertain: false

--- a/src/Application/AnalyzeCommand.php
+++ b/src/Application/AnalyzeCommand.php
@@ -257,7 +257,6 @@ final class AnalyzeCommand extends Command
         $analysisResult = $this->phpStanRunner->run(
             $output,
             $errorOutput,
-            __DIR__ . '/../../config/phpstan.neon',
             $this->environmentLoader,
             [
                 ...$phpFileNames,
@@ -324,7 +323,6 @@ final class AnalyzeCommand extends Command
         $analysisResult = $this->phpStanRunner->run(
             $output,
             $errorOutput,
-            __DIR__ . '/../../config/phpstan.neon',
             $this->environmentLoader,
             $phpFileNamesToAnalyze,
             $debugMode,

--- a/src/DependencyInjection/SchemaFactory.php
+++ b/src/DependencyInjection/SchemaFactory.php
@@ -42,6 +42,16 @@ final readonly class SchemaFactory
                     ),
                     'excludes' => Expect::listOf('string'),
                 ])->castTo('array'),
+                'phpstan' => Expect::structure([
+                    'configurationFile' => Expect::string()->transform(
+                        fn(string $path) => Path::makeAbsolute($path, $basePath),
+                    ),
+                    'memoryLimit' => Expect::anyOf(
+                        Expect::string(),
+                        Expect::bool()->assert(fn($value) => $value === false, 'Only false is accepted')->transform(fn() => '-1'),
+                        Expect::null(),
+                    ),
+                ])->castTo('array'),
                 'environmentLoader' => Expect::string()->transform(
                     fn(string $path) => Path::makeAbsolute($path, $basePath),
                 ),

--- a/tests/twigstan.neon
+++ b/tests/twigstan.neon
@@ -1,8 +1,10 @@
 parameters:
+	phpstan:
+		configurationFile: ../phpstan.neon
+	environmentLoader: twig-loader.php
 	twig:
 		paths: []
 		excludes: []
 	php:
 		paths: []
 		excludes: []
-	environmentLoader: twig-loader.php

--- a/twigstan.neon.dist
+++ b/twigstan.neon.dist
@@ -1,4 +1,12 @@
 parameters:
+	phpstan:
+		# Path to PHPStan configuration file
+		configurationFile: phpstan.neon
+
+		# Memory limit for when running PHPStan. Should be a value accepted by PHP (e.g. 512M)
+		# Use false for no limit
+		#memoryLimit: null
+
 	# TwigStan needs access to your Twig environment to analyze your templates.
 	environmentLoader: twig-loader.php
 


### PR DESCRIPTION
We should use the already existing PHPStan configuration from the project.

This way, we use the same settings (like level and extensions).

TwigStan only needs a few modifications to run.

Also added a phpstan.memoryLimit option.

Fixes #12
