### PR TITLE
Optimize analysis to json

### DIFF
--- a/src/PHPStan/AnalysisResultToJson.php
+++ b/src/PHPStan/AnalysisResultToJson.php
@@ -42,15 +42,7 @@ final readonly class AnalysisResultToJson implements ErrorFormatter
             json_encode([
                 'fileSpecificErrors' => $analysisResult->getFileSpecificErrors(),
                 'notFileSpecificErrors' => $analysisResult->getNotFileSpecificErrors(),
-                'internalErrors' => $analysisResult->getInternalErrorObjects(),
-                'warnings' => $analysisResult->getWarnings(),
                 'collectedData' => $analysisResult->getCollectedData(),
-                'defaultLevelUsed' => $analysisResult->isDefaultLevelUsed(),
-                'projectConfigFile' => $analysisResult->getProjectConfigFile(),
-                'savedResultCache' => $analysisResult->isResultCacheSaved(),
-                'peakMemoryUsageBytes' => $analysisResult->getPeakMemoryUsageBytes(),
-                'isResultCacheUsed' => $analysisResult->isResultCacheUsed(),
-                'changedProjectExtensionFilesOutsideOfAnalysedPaths' => $analysisResult->getChangedProjectExtensionFilesOutsideOfAnalysedPaths(),
             ]),
         );
 

--- a/src/PHPStan/AnalysisResultToJson.php
+++ b/src/PHPStan/AnalysisResultToJson.php
@@ -8,6 +8,7 @@ use PHPStan\Command\AnalysisResult;
 use PHPStan\Command\ErrorFormatter\ErrorFormatter;
 use PHPStan\Command\ErrorFormatter\JsonErrorFormatter;
 use PHPStan\Command\Output;
+use TwigStan\PHPStan\Collector\ExportingCollector;
 
 /**
  * This is abusing the ErrorFormatter to write the AnalysisResult to a JSON file.
@@ -42,7 +43,11 @@ final readonly class AnalysisResultToJson implements ErrorFormatter
             json_encode([
                 'fileSpecificErrors' => $analysisResult->getFileSpecificErrors(),
                 'notFileSpecificErrors' => $analysisResult->getNotFileSpecificErrors(),
-                'collectedData' => $analysisResult->getCollectedData(),
+                'collectedData' => array_filter(
+                    $analysisResult->getCollectedData(),
+                    // @phpstan-ignore phpstanApi.runtimeReflection
+                    fn($collectedData) => is_a($collectedData->getCollectorType(), ExportingCollector::class, true),
+                ),
             ]),
         );
 

--- a/src/PHPStan/Collector/BlockContextCollector.php
+++ b/src/PHPStan/Collector/BlockContextCollector.php
@@ -20,7 +20,7 @@ use TwigStan\Twig\SourceLocation;
  *     parent: bool,
  * }>
  */
-final readonly class BlockContextCollector implements Collector
+final readonly class BlockContextCollector implements Collector, ExportingCollector
 {
     public function getNodeType(): string
     {

--- a/src/PHPStan/Collector/ExportingCollector.php
+++ b/src/PHPStan/Collector/ExportingCollector.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\PHPStan\Collector;
+
+interface ExportingCollector {}

--- a/src/PHPStan/Collector/TemplateContextCollector.php
+++ b/src/PHPStan/Collector/TemplateContextCollector.php
@@ -16,4 +16,4 @@ use PHPStan\Collectors\Collector;
  * @template-covariant TNodeType of Node
  * @extends Collector<TNodeType, non-empty-list<TemplateData>>
  */
-interface TemplateContextCollector extends Collector {}
+interface TemplateContextCollector extends Collector, ExportingCollector {}


### PR DESCRIPTION
### Only take from analysis result what we need

### Only export our own collectors

Since we run in the PHPStan configuration of the user, there might be many more collectors.

We don't need that data.
