### PR TITLE
Baseline functionality

### DIFF
--- a/config/application.neon
+++ b/config/application.neon
@@ -1,4 +1,5 @@
 parameters:
+	reportUnmatchedIgnoredErrors: true
 	phpstan:
 		configurationFile: phpstan.neon
 		memoryLimit: null
@@ -8,6 +9,7 @@ parameters:
 	twig:
 		paths: []
 		excludes: []
+	baselineErrors: []
 	ignoreErrors:
 		-
 			identifier: isset.variable
@@ -65,12 +67,16 @@ services:
 	- TwigStan\PHP\PrettyPrinter
 	- TwigStan\PHP\StrictPhpParser
 	- TwigStan\PHPStan\Analysis\AnalysisResultFromJsonReader
-	- TwigStan\PHPStan\Analysis\ErrorCollapser
-	- TwigStan\PHPStan\Analysis\ErrorFilter(
+	- TwigStan\Error\ErrorCollapser
+	- TwigStan\Error\ErrorFilter(
 		ignoreErrors: %ignoreErrors%
 	)
-	- TwigStan\PHPStan\Analysis\ErrorToSourceFileMapper
-	- TwigStan\PHPStan\Analysis\ErrorTransformer
+	- TwigStan\Error\BaselineErrorFilter(
+		baselineErrors: %baselineErrors%
+		reportUnmatchedIgnoredErrors: %reportUnmatchedIgnoredErrors%
+	)
+	- TwigStan\Error\ErrorToSourceFileMapper
+	- TwigStan\Error\ErrorTransformer
 	- TwigStan\Processing\Compilation\ModifiedCompiler
 	- TwigStan\Processing\Compilation\Parser\TwigNodeParser
 	- TwigStan\Processing\Compilation\TwigCompiler

--- a/src/Application/PHPStanRunner.php
+++ b/src/Application/PHPStanRunner.php
@@ -10,8 +10,6 @@ use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\Process;
 use TwigStan\PHPStan\Analysis\AnalysisResultFromJsonReader;
 use TwigStan\PHPStan\Analysis\PHPStanAnalysisResult;
-use TwigStan\Processing\Flattening\FlatteningResultCollection;
-use TwigStan\Processing\ScopeInjection\ScopeInjectionResultCollection;
 
 final readonly class PHPStanRunner
 {
@@ -33,7 +31,6 @@ final readonly class PHPStanRunner
         array $pathsToAnalyze,
         bool $debugMode,
         bool $xdebugMode,
-        FlatteningResultCollection | ScopeInjectionResultCollection $mapping,
         bool $collectOnly = false,
     ): PHPStanAnalysisResult {
         $tempConfigFile = tempnam(sys_get_temp_dir(), 'twigstan-phpstan-');
@@ -103,7 +100,7 @@ final readonly class PHPStanRunner
             $output->write($buffer);
         });
 
-        $analysisResult = $this->analysisResultFromJsonReader->read($analysisResultJsonFile, $mapping);
+        $analysisResult = $this->analysisResultFromJsonReader->read($analysisResultJsonFile);
 
         $this->filesystem->remove($tempConfigFile);
         $this->filesystem->remove($analysisResultJsonFile);

--- a/src/Application/TwigStanError.php
+++ b/src/Application/TwigStanError.php
@@ -15,8 +15,8 @@ final readonly class TwigStanError
         public string $message,
         public ?string $identifier,
         public ?string $tip,
-        public string $phpFile,
-        public int $phpLine,
+        public ?string $phpFile,
+        public ?int $phpLine,
         public ?SourceLocation $twigSourceLocation,
         public array $renderPoints,
     ) {}

--- a/src/DependencyInjection/SchemaFactory.php
+++ b/src/DependencyInjection/SchemaFactory.php
@@ -7,6 +7,7 @@ namespace TwigStan\DependencyInjection;
 use Nette\Schema\Elements\Structure;
 use Nette\Schema\Expect;
 use Symfony\Component\Filesystem\Path;
+use TwigStan\Error\BaselineError;
 use TwigStan\Error\IgnoreError;
 
 final readonly class SchemaFactory
@@ -24,6 +25,7 @@ final readonly class SchemaFactory
             ),
             'services' => Expect::array(),
             'parameters' => Expect::structure([
+                'reportUnmatchedIgnoredErrors' => Expect::anyOf(Expect::bool(), Expect::null()),
                 'php' => Expect::structure([
                     'paths' => Expect::listOf('string')->transform(
                         fn(array $directories) => array_map(
@@ -68,6 +70,12 @@ final readonly class SchemaFactory
                         Expect::null(),
                     ),
                 ])->castTo(IgnoreError::class)),
+                'baselineErrors' => Expect::listOf(Expect::structure([
+                    'message' => Expect::string(),
+                    'identifier' => Expect::anyOf(Expect::string(), Expect::null()),
+                    'path' => Expect::string(),
+                    'count' => Expect::int(),
+                ])->castTo(BaselineError::class)),
             ])->skipDefaults()->castTo('array'),
         ])->skipDefaults()->castTo('array');
     }

--- a/src/Error/Baseline/BaselineDumper.php
+++ b/src/Error/Baseline/BaselineDumper.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\Error\Baseline;
+
+use TwigStan\Error\BaselineError;
+
+interface BaselineDumper
+{
+    /**
+     * @param list<BaselineError> $errors
+     */
+    public function dump(array $errors): string;
+}

--- a/src/Error/Baseline/NeonBaselineDumper.php
+++ b/src/Error/Baseline/NeonBaselineDumper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\Error\Baseline;
+
+use Nette\Neon\Neon;
+use TwigStan\Error\BaselineError;
+
+final readonly class NeonBaselineDumper implements BaselineDumper
+{
+    public function dump(array $errors): string
+    {
+        return Neon::encode([
+            'parameters' => [
+                'baselineErrors' => array_map(
+                    fn(BaselineError $error): array => [
+                        'message' => $error->message,
+                        'identifier' => $error->identifier,
+                        'path' => $error->path,
+                        'count' => $error->count,
+                    ],
+                    $errors,
+                ),
+            ],
+        ], true);
+    }
+}

--- a/src/Error/BaselineError.php
+++ b/src/Error/BaselineError.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\Error;
+
+use Stringable;
+use TwigStan\PHPStan\Analysis\Error;
+
+final class BaselineError implements Stringable
+{
+    public function __construct(
+        public string $message,
+        public ?string $identifier,
+        public string $path,
+        public int $count = 1,
+        public int $hits = 0,
+    ) {}
+
+    public function increaseCount(): void
+    {
+        $this->count++;
+    }
+
+    public function shouldIgnore(Error $error): bool
+    {
+        if ($error->sourceLocation === null) {
+            return false;
+        }
+
+        if ($this->identifier !== null && $this->identifier !== $error->identifier) {
+            return false;
+        }
+
+        if ($this->message !== $error->message) {
+            return false;
+        }
+
+        if ($this->path === $error->sourceLocation->fileName) {
+            return false;
+        }
+
+        $this->hits++;
+
+        if ($this->hits > $this->count) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function __toString(): string
+    {
+        $message = $this->message;
+        if ($this->identifier !== null) {
+            $message = sprintf('%s (%s)', $message, $this->identifier);
+        }
+
+        return sprintf('%s in path %s', $message, $this->path);
+    }
+}

--- a/src/Error/BaselineErrorFilter.php
+++ b/src/Error/BaselineErrorFilter.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\Error;
+
+use TwigStan\PHPStan\Analysis\Error;
+
+final readonly class BaselineErrorFilter
+{
+    /**
+     * @param list<BaselineError> $baselineErrors
+     */
+    public function __construct(
+        private array $baselineErrors,
+        private bool $reportUnmatchedIgnoredErrors,
+    ) {}
+
+
+    /**
+     * @param list<Error> $errors
+     *
+     * @return list<Error>
+     */
+    public function filter(array $errors): array
+    {
+        $errors = array_values(array_filter(
+            $errors,
+            function ($error) {
+                foreach ($this->baselineErrors as $baselineError) {
+                    if ($baselineError->shouldIgnore($error)) {
+                        return false;
+                    }
+                }
+
+                return true;
+            },
+        ));
+
+        foreach ($this->baselineErrors as $baselineError) {
+            if ($baselineError->hits === $baselineError->count) {
+                continue;
+            }
+
+            if (!$this->reportUnmatchedIgnoredErrors && $baselineError->count > $baselineError->hits) {
+                continue;
+            }
+
+            $errors[] = new Error(
+                sprintf(
+                    "Baseline error is expected to occur %d %s, but occurred only %d %s.\n%s",
+                    $baselineError->count,
+                    $baselineError->count === 1 ? 'time' : 'times',
+                    $baselineError->hits,
+                    $baselineError->hits === 1 ? 'time' : 'times',
+                    $baselineError,
+                ),
+                null,
+                0,
+                null,
+                null,
+                'ignore.count',
+                null,
+                false,
+            );
+        }
+
+        return $errors;
+    }
+}

--- a/src/Error/ErrorCollapser.php
+++ b/src/Error/ErrorCollapser.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace TwigStan\PHPStan\Analysis;
+namespace TwigStan\Error;
+
+use TwigStan\PHPStan\Analysis\Error;
 
 final readonly class ErrorCollapser
 {

--- a/src/Error/ErrorFilter.php
+++ b/src/Error/ErrorFilter.php
@@ -2,9 +2,9 @@
 
 declare(strict_types=1);
 
-namespace TwigStan\PHPStan\Analysis;
+namespace TwigStan\Error;
 
-use TwigStan\Error\IgnoreError;
+use TwigStan\PHPStan\Analysis\Error;
 
 final readonly class ErrorFilter
 {

--- a/src/Error/ErrorToSourceFileMapper.php
+++ b/src/Error/ErrorToSourceFileMapper.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace TwigStan\PHPStan\Analysis;
+namespace TwigStan\Error;
 
+use TwigStan\PHPStan\Analysis\Error;
 use TwigStan\Processing\ScopeInjection\ScopeInjectionResultCollection;
 
 final readonly class ErrorToSourceFileMapper
@@ -17,6 +18,10 @@ final readonly class ErrorToSourceFileMapper
     {
         return array_map(
             function (Error $error) use ($mapping) {
+                if ($error->phpFile === null) {
+                    return $error;
+                }
+
                 if (!$mapping->hasPhpFile($error->phpFile)) {
                     return $error;
                 }

--- a/src/Error/ErrorTransformer.php
+++ b/src/Error/ErrorTransformer.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-namespace TwigStan\PHPStan\Analysis;
+namespace TwigStan\Error;
+
+use TwigStan\PHPStan\Analysis\Error;
 
 final readonly class ErrorTransformer
 {

--- a/src/Error/IgnoreError.php
+++ b/src/Error/IgnoreError.php
@@ -6,12 +6,13 @@ namespace TwigStan\Error;
 
 use TwigStan\PHPStan\Analysis\Error;
 
-final readonly class IgnoreError
+final class IgnoreError
 {
     public function __construct(
         public ?string $message = null,
         public ?string $identifier = null,
         public ?string $path = null,
+        public int $hits = 0,
     ) {}
 
     public function shouldIgnore(Error $error): bool
@@ -27,6 +28,8 @@ final readonly class IgnoreError
         if ($this->path !== null && ($error->sourceLocation === null || !fnmatch($this->path, $error->sourceLocation->fileName, FNM_NOESCAPE))) {
             return false;
         }
+
+        $this->hits++;
 
         return true;
     }

--- a/src/PHPStan/Analysis/AnalysisResultFromJsonReader.php
+++ b/src/PHPStan/Analysis/AnalysisResultFromJsonReader.php
@@ -6,20 +6,14 @@ namespace TwigStan\PHPStan\Analysis;
 
 use InvalidArgumentException;
 use Symfony\Component\Filesystem\Filesystem;
-use TwigStan\Processing\Flattening\FlatteningResultCollection;
-use TwigStan\Processing\ScopeInjection\ScopeInjectionResultCollection;
 
 final readonly class AnalysisResultFromJsonReader
 {
     public function __construct(
-        private ErrorFilter $errorFilter,
-        private ErrorCollapser $errorCollapser,
-        private ErrorTransformer $errorTransformer,
-        private ErrorToSourceFileMapper $errorToSourceFileMapper,
         private Filesystem $filesystem,
     ) {}
 
-    public function read(string $file, FlatteningResultCollection | ScopeInjectionResultCollection $mapping): PHPStanAnalysisResult
+    public function read(string $file): PHPStanAnalysisResult
     {
         if (!file_exists($file)) {
             return new PHPStanAnalysisResult(
@@ -44,18 +38,8 @@ final readonly class AnalysisResultFromJsonReader
             $result['fileSpecificErrors'],
         ));
 
-        if ($mapping instanceof ScopeInjectionResultCollection) {
-            $errors = $this->errorToSourceFileMapper->map(
-                $mapping,
-                $errors,
-            );
-        }
-
-        $errors = $this->errorFilter->filter($errors);
-        $errors = $this->errorCollapser->collapse($errors);
-
         return new PHPStanAnalysisResult(
-            $this->errorTransformer->transform($errors),
+            $errors,
             array_values(array_map(
                 CollectedData::decode(...),
                 $result['collectedData'],

--- a/src/PHPStan/Analysis/Error.php
+++ b/src/PHPStan/Analysis/Error.php
@@ -10,12 +10,13 @@ final readonly class Error
 {
     public function __construct(
         public string $message,
-        public string $phpFile,
+        public ?string $phpFile,
         public int $phpLine,
         public ?string $twigFile,
         public ?SourceLocation $sourceLocation,
         public ?string $identifier,
         public ?string $tip,
+        public bool $canBeIgnored = true,
     ) {}
 
     /**
@@ -31,6 +32,7 @@ final readonly class Error
             null,
             $json['identifier'],
             $json['tip'],
+            $json['canBeIgnored'],
         );
     }
 

--- a/tests/Baseline/BaselineTest.php
+++ b/tests/Baseline/BaselineTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\Baseline;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Throwable;
+use TwigStan\Application\AnalyzeCommand;
+use TwigStan\DependencyInjection\ContainerFactory;
+use TwigStan\ErrorHelper;
+
+final class BaselineTest extends TestCase
+{
+    private BufferedOutput $output;
+    private BufferedOutput $errorOutput;
+
+    protected function setUp(): void
+    {
+        $this->output = new BufferedOutput();
+        $this->errorOutput = new BufferedOutput();
+    }
+
+    protected function onNotSuccessfulTest(Throwable $t): never
+    {
+        echo $this->output->fetch();
+        echo $this->errorOutput->fetch();
+
+        throw $t;
+    }
+
+    public function testBaseline(): void
+    {
+        $baseline = __DIR__ . '/baseline.neon';
+
+        $result = $this->getAnalyzeCommand(__DIR__ . '/twigstan.neon')->analyze(
+            ['tests/Baseline'],
+            $this->output,
+            $this->errorOutput,
+            extension_loaded('xdebug') ? true : false,
+            extension_loaded('xdebug') ? true : false,
+            $baseline,
+        );
+
+        self::assertSame([], $result->errors);
+        self::assertSame([], $result->fileSpecificErrors);
+
+        self::assertFileEquals(__DIR__ . '/expected.neon', $baseline);
+    }
+
+    public function testWithoutBaseline(): void
+    {
+        $result = $this->getAnalyzeCommand(__DIR__ . '/../twigstan.neon')->analyze(
+            ['tests/Baseline'],
+            $this->output,
+            $this->errorOutput,
+            extension_loaded('xdebug') ? true : false,
+            extension_loaded('xdebug') ? true : false,
+            null,
+        );
+
+        ErrorHelper::assertAnalysisResultMatchesJsonFile($result, __DIR__);
+    }
+
+    private function getAnalyzeCommand(string $configurationFile): AnalyzeCommand
+    {
+        $containerFactory = new ContainerFactory(
+            dirname(__DIR__, 2),
+            $configurationFile,
+        );
+        $container = $containerFactory->create();
+
+        return $container->getByType(AnalyzeCommand::class);
+    }
+}

--- a/tests/Baseline/baseline.neon
+++ b/tests/Baseline/baseline.neon
@@ -1,0 +1,26 @@
+parameters:
+	baselineErrors:
+		-
+			message: If condition is always false.
+			identifier: if.alwaysFalse
+			path: tests/Baseline/homepage.html.twig
+			count: 1
+
+		-
+			message: 'Undefined variable: name'
+			identifier: variable.undefined
+			path: tests/Baseline/layout.html.twig
+			count: 3
+
+		-
+			message: 'Undefined variable: email'
+			identifier: variable.undefined
+			path: tests/Baseline/layout.html.twig
+			count: 2
+
+		-
+			message: 'Undefined variable: userId'
+			identifier: variable.undefined
+			path: tests/Baseline/layout.html.twig
+			count: 1
+

--- a/tests/Baseline/errors.json
+++ b/tests/Baseline/errors.json
@@ -1,0 +1,54 @@
+{
+    "errors": [
+        {
+            "message": "If condition is always false.",
+            "identifier": "if.alwaysFalse",
+            "tip": null,
+            "twigSourceLocation": "homepage.html.twig:3",
+            "renderPoints": []
+        },
+        {
+            "message": "Undefined variable: name",
+            "identifier": "variable.undefined",
+            "tip": null,
+            "twigSourceLocation": "layout.html.twig:1",
+            "renderPoints": []
+        },
+        {
+            "message": "Undefined variable: name",
+            "identifier": "variable.undefined",
+            "tip": null,
+            "twigSourceLocation": "layout.html.twig:3",
+            "renderPoints": []
+        },
+        {
+            "message": "Undefined variable: name",
+            "identifier": "variable.undefined",
+            "tip": null,
+            "twigSourceLocation": "layout.html.twig:5",
+            "renderPoints": []
+        },
+        {
+            "message": "Undefined variable: email",
+            "identifier": "variable.undefined",
+            "tip": null,
+            "twigSourceLocation": "layout.html.twig:7",
+            "renderPoints": []
+        },
+        {
+            "message": "Undefined variable: email",
+            "identifier": "variable.undefined",
+            "tip": null,
+            "twigSourceLocation": "layout.html.twig:8",
+            "renderPoints": []
+        },
+        {
+            "message": "Undefined variable: userId",
+            "identifier": "variable.undefined",
+            "tip": null,
+            "twigSourceLocation": "layout.html.twig:10",
+            "renderPoints": []
+        }
+    ],
+    "fileSpecificErrors": []
+}

--- a/tests/Baseline/expected.neon
+++ b/tests/Baseline/expected.neon
@@ -1,0 +1,26 @@
+parameters:
+	baselineErrors:
+		-
+			message: If condition is always false.
+			identifier: if.alwaysFalse
+			path: tests/Baseline/homepage.html.twig
+			count: 1
+
+		-
+			message: 'Undefined variable: name'
+			identifier: variable.undefined
+			path: tests/Baseline/layout.html.twig
+			count: 3
+
+		-
+			message: 'Undefined variable: email'
+			identifier: variable.undefined
+			path: tests/Baseline/layout.html.twig
+			count: 2
+
+		-
+			message: 'Undefined variable: userId'
+			identifier: variable.undefined
+			path: tests/Baseline/layout.html.twig
+			count: 1
+

--- a/tests/Baseline/homepage.html.twig
+++ b/tests/Baseline/homepage.html.twig
@@ -1,0 +1,5 @@
+{% set title = false %}
+
+{% if title %}
+    This cannot ever be true
+{% endif %}

--- a/tests/Baseline/layout.html.twig
+++ b/tests/Baseline/layout.html.twig
@@ -1,0 +1,10 @@
+Hello, {{ name }}!
+
+How are you {{ name }}?
+
+{{ name }}
+
+{{ email }}
+{{ email }}
+
+{{ userId }}

--- a/tests/Baseline/twigstan.neon
+++ b/tests/Baseline/twigstan.neon
@@ -1,0 +1,3 @@
+includes:
+	- ../twigstan.neon
+	- baseline.neon

--- a/tests/ErrorHelper.php
+++ b/tests/ErrorHelper.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan;
+
+use PHPUnit\Framework\Assert;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
+use TwigStan\Application\TwigStanAnalysisResult;
+use TwigStan\Application\TwigStanError;
+
+final readonly class ErrorHelper
+{
+    public static function assertAnalysisResultMatchesJsonFile(TwigStanAnalysisResult $result, string $directory): void
+    {
+        $filesystem = new Filesystem();
+        $expectedErrors = json_decode(
+            $filesystem->readFile(Path::join($directory, 'errors.json')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+        $actual = self::toArray($result, $directory);
+
+        $expectedButNotActual = [];
+        $actualErrorsNotExpected = $actual['errors'];
+        foreach ($expectedErrors['errors'] as $expectedError) {
+            $key = array_search($expectedError, $actualErrorsNotExpected, true);
+            if ($key !== false) {
+                unset($actualErrorsNotExpected[$key]);
+                continue;
+            }
+
+            $expectedButNotActual[] = $expectedError;
+        }
+        $actualErrorsNotExpected = array_values($actualErrorsNotExpected);
+
+        Assert::assertTrue(
+            $expectedButNotActual === [] && $actualErrorsNotExpected === [],
+            sprintf(
+                "The following errors were expected but not found: %s\n\nThe following errors were found but not expected: %s",
+                json_encode(
+                    $expectedButNotActual,
+                    JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT,
+                ),
+                json_encode(
+                    $actualErrorsNotExpected,
+                    JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT,
+                ),
+            ),
+        );
+
+        Assert::assertEqualsCanonicalizing(
+            $expectedErrors['fileSpecificErrors'],
+            $actual['fileSpecificErrors'],
+            sprintf(
+                'FileSpecificErrors do not match with expectations. The full actual result is: %s',
+                json_encode($actual, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT),
+            ),
+        );
+    }
+    /**
+     *
+     * @return array{
+     *     errors: list<array{
+     *          message: string,
+     *          identifier: string|null,
+     *          tip: string|null,
+     *          twigSourceLocation: string|null,
+     *          renderPoints: array<string>,
+     *     }>,
+     *     fileSpecificErrors: list<string>,
+     * }
+     */
+    private static function toArray(TwigStanAnalysisResult $result, string $directory): array
+    {
+        return [
+            'errors' => array_map(
+                fn($error) => self::errorToArray($error, $directory),
+                $result->errors,
+            ),
+            'fileSpecificErrors' => $result->fileSpecificErrors,
+        ];
+    }
+
+    /**
+     * @return array{
+     *      message: string,
+     *      identifier: string|null,
+     *      tip: string|null,
+     *      twigSourceLocation: string|null,
+     *      renderPoints: array<string>,
+     * }
+     */
+    private static function errorToArray(TwigStanError $error, string $directory): array
+    {
+        return [
+            'message' => $error->message,
+            'identifier' => $error->identifier,
+            'tip' => $error->tip,
+            'twigSourceLocation' => $error->twigSourceLocation?->toString($directory),
+            'renderPoints' => array_map(
+                fn($sourceLocation) => $sourceLocation->toString($directory),
+                $error->renderPoints,
+            ),
+        ];
+    }
+}

--- a/tests/twigstan.neon
+++ b/tests/twigstan.neon
@@ -1,4 +1,5 @@
 parameters:
+	tempDir: .twigstan
 	phpstan:
 		configurationFile: ../phpstan.neon
 	environmentLoader: twig-loader.php

--- a/twigstan-baseline.neon
+++ b/twigstan-baseline.neon
@@ -1,0 +1,26 @@
+parameters:
+	baselineErrors:
+		-
+			message: If condition is always false.
+			identifier: if.alwaysFalse
+			path: tests/EndToEnd/Baseline/homepage.html.twig
+			count: 1
+
+		-
+			message: 'Undefined variable: name'
+			identifier: variable.undefined
+			path: tests/EndToEnd/Baseline/layout.html.twig
+			count: 3
+
+		-
+			message: 'Undefined variable: email'
+			identifier: variable.undefined
+			path: tests/EndToEnd/Baseline/layout.html.twig
+			count: 2
+
+		-
+			message: 'Undefined variable: userId'
+			identifier: variable.undefined
+			path: tests/EndToEnd/Baseline/layout.html.twig
+			count: 1
+


### PR DESCRIPTION
This introduces a basic baseline functionality similar to PHPStan. Except that it uses the `baselineErrors` key in the configuration.

You can use --generate-baseline to generate the baseline and include that.

There is a `reportUnmatchedIgnoredErrors` option to control what should happen when the baseline error does not match.

Note that `reportUnmatchedIgnoredErrors` does not yet work for `ignoreErrors`.

Closes #18
Fixes #9