### PR TITLE
Add include failing test

### DIFF
--- a/tests/EndToEnd/Include/IncludeTest.php
+++ b/tests/EndToEnd/Include/IncludeTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\EndToEnd\Include;
+
+use TwigStan\EndToEnd\AbstractEndToEndTestCase;
+
+final class IncludeTest extends AbstractEndToEndTestCase
+{
+    public function test(): void
+    {
+        parent::runTests(__DIR__);
+    }
+}

--- a/tests/EndToEnd/Include/_layout.twig
+++ b/tests/EndToEnd/Include/_layout.twig
@@ -1,0 +1,2 @@
+{% include '@EndToEnd/Include/included.twig' %}
+

--- a/tests/EndToEnd/Include/errors.json
+++ b/tests/EndToEnd/Include/errors.json
@@ -1,0 +1,4 @@
+{
+    "errors": [],
+    "fileSpecificErrors": []
+}

--- a/tests/EndToEnd/Include/included.twig
+++ b/tests/EndToEnd/Include/included.twig
@@ -1,0 +1,1 @@
+Included


### PR DESCRIPTION
- Undefined variable: context error should not be throw

- Call to an undefined method __TwigTemplate_01e5fd7706178cff046f718e88f3c579::loadTemplate() error should not be throw