### PR TITLE
Add Inherited Render Point failing test

### DIFF
--- a/tests/EndToEnd/RenderPoints/InheritedRenderPointController.php
+++ b/tests/EndToEnd/RenderPoints/InheritedRenderPointController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace TwigStan\EndToEnd\RenderPoints;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+
+class InheritedRenderPointController extends AbstractController
+{
+    public function renderAction(): Response
+    {
+        $response = new Response(status: Response::HTTP_CREATED);
+
+        return $this->render('EndToEnd/RenderPoints/child.twig', [
+            'title' => 'RenderAction',
+            'description' => 'Description',
+        ], $response);
+    }
+
+    public function renderViewAction(): Response
+    {
+        return new Response($this->renderView('EndToEnd/RenderPoints/child.twig', [
+            'title' => 'RenderViewAction',
+            'description' => 'Description',
+        ]));
+    }
+}

--- a/tests/EndToEnd/RenderPoints/base.twig
+++ b/tests/EndToEnd/RenderPoints/base.twig
@@ -1,0 +1,6 @@
+{% block title %}
+    {{ title }}
+{% endblock %}
+
+{% block description %}
+{% endblock %}

--- a/tests/EndToEnd/RenderPoints/child.twig
+++ b/tests/EndToEnd/RenderPoints/child.twig
@@ -1,0 +1,5 @@
+{% extends 'EndToEnd/RenderPoints/base.twig' %}
+
+{% block description %}
+    {{ description }}
+{% endblock %}


### PR DESCRIPTION
Hi @ruudk,

I added failing test with inherited template and render point.

As you can see, if render point inject title in child template, but the variable is use in parent template also, the variable.undefined error thrown.