### PR TITLE
Collect context for include calls in Twig

### DIFF
--- a/config/phpstan.neon
+++ b/config/phpstan.neon
@@ -43,6 +43,10 @@ services:
 		tags:
 			- phpstan.collector
 	-
+		class: TwigStan\PHPStan\Collector\ContextFromTwigIncludeCallCollector
+		tags:
+			- phpstan.collector
+	-
 		class: TwigStan\PHPStan\Collector\ContextFromTwigRenderMethodCallCollector
 		tags:
 			- phpstan.collector

--- a/src/Application/AnalyzeCommand.php
+++ b/src/Application/AnalyzeCommand.php
@@ -323,8 +323,12 @@ final class AnalyzeCommand extends Command
             if (is_a($data->collecterType, TemplateContextCollector::class, true)) {
                 foreach ($data->data as $renderData) {
                     try {
+                        $filePath = $data->filePath;
+                        if ($flatteningResults->hasPhpFile($data->filePath)) {
+                            $filePath = $flatteningResults->getByPhpFile($data->filePath)->twigFileName;
+                        }
                         $template = $this->twigFileCanonicalizer->canonicalize($renderData['template']);
-                        $templateToRenderPoint[$template][$data->filePath][] = $renderData['startLine'];
+                        $templateToRenderPoint[$template][$filePath][] = $renderData['startLine'];
                     } catch (UnableToCanonicalizeTwigFileException) {
                         // Ignore
                     }

--- a/src/PHPStan/Collector/ContextFromTwigIncludeCallCollector.php
+++ b/src/PHPStan/Collector/ContextFromTwigIncludeCallCollector.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\PHPStan\Collector;
+
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\PhpDocParser\Printer\Printer;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+
+/**
+ * @implements TemplateContextCollector<Node\Expr\MethodCall>
+ */
+final readonly class ContextFromTwigIncludeCallCollector implements TemplateContextCollector
+{
+    public function getNodeType(): string
+    {
+        return Node\Expr\MethodCall::class;
+    }
+
+    public function processNode(Node $node, Scope $scope): ?array
+    {
+        // Find: $this->include(\get_defined_vars(), "@EndToEnd/Include/footer.twig", [], \false, \false);
+
+        if ( ! $node->var instanceof Node\Expr\Variable) {
+            return null;
+        }
+
+        if ($node->var->name !== 'this') {
+            return null;
+        }
+
+        if ( ! $node->name instanceof Node\Identifier) {
+            return null;
+        }
+
+        if ($node->name->name !== 'include') {
+            return null;
+        }
+
+        $args = $node->getArgs();
+
+        if (count($args) < 4) {
+            return null;
+        }
+
+        $context = $scope->getType($args[0]->value)->getConstantArrays();
+
+        if (count($context) !== 1) {
+            return null;
+        }
+
+        $context = $context[0];
+
+        $templates = $scope->getType($args[1]->value)->getConstantStrings();
+        if (count($templates) === 0) {
+            return null;
+        }
+
+        $variables = $scope->getType($args[2]->value)->getConstantArrays();
+
+        if (count($variables) !== 1) {
+            return null;
+        }
+
+        $variables = $variables[0];
+
+        $withContext = $scope->getType($args[3]->value)->isTrue()->yes();
+
+        if ($withContext) {
+            $builder = ConstantArrayTypeBuilder::createFromConstantArray($context);
+
+            foreach ($variables->getKeyTypes() as $key) {
+                $builder->setOffsetValueType($key, $variables->getOffsetValueType($key));
+            }
+
+            $templateContext = $builder->getArray();
+        } else {
+            $templateContext = $variables;
+        }
+
+        $result = [];
+        foreach ($templates as $template) {
+            $result[] = [
+                'startLine' => $node->getStartLine(),
+                'endLine' => $node->getEndLine(),
+                'template' => $template->getValue(),
+                'context' => (new Printer())->print($templateContext->toPhpDocNode()),
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/tests/EndToEnd/Include/footer.twig
+++ b/tests/EndToEnd/Include/footer.twig
@@ -1,1 +1,4 @@
 Footer
+
+{% assert_variable_exists title maybe %}
+{% assert_variable_exists somethingInTheContext maybe %}

--- a/tests/EndToEnd/Include/include_block.twig
+++ b/tests/EndToEnd/Include/include_block.twig
@@ -1,3 +1,5 @@
+{% set somethingInTheContext = true %}
+
 {% include '@EndToEnd/Include/footer.twig' %}
 {% include '@EndToEnd/Include/footer.twig' only %}
 {% include '@EndToEnd/Include/footer.twig' with { title: 'Hello, World!' } %}

--- a/tests/EndToEnd/Include/include_function.twig
+++ b/tests/EndToEnd/Include/include_function.twig
@@ -1,3 +1,5 @@
+{% set somethingInTheContext = true %}
+
 {{ include('@EndToEnd/Include/footer.twig') }}
 {{ include('@EndToEnd/Include/footer.twig', with_context = false) }}
 {{ include('@EndToEnd/Include/footer.twig', { title: 'Hello, World!' }) }}


### PR DESCRIPTION
Whenever you include a template inside a Twig template, we can collect the
context that is passed to the template.

We can then inject this into the compiled template so that we have type information there too.

This is still limited, as this currently only collects the variables defined in the template
that includes it.

We should think about how to get the context that is passed from the controller. Maybe this will
require another PHPStan run.
