### PR TITLE
Bump nikic/php-parser to ^5.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "nette/bootstrap": "^3.2",
         "nette/di": "^3.2.2",
         "nette/neon": "^3.4",
-        "nikic/php-parser": "^4.18.0",
+        "nikic/php-parser": "^5.1.0",
         "phpstan/phpdoc-parser": "^1.30",
         "phpstan/phpstan": "^1.12.6",
         "symfony/console": "^7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c59a93e4aa929e90e01cc09192f0e59",
+    "content-hash": "169e9dd7191b1851d2aca2dff1eb1b38",
     "packages": [
         {
             "name": "nette/bootstrap",
@@ -513,25 +513,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.2",
+            "version": "v5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "0ed4c8949a32986043e977dbe14776c14d644c45"
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/0ed4c8949a32986043e977dbe14776c14d644c45",
-                "reference": "0ed4c8949a32986043e977dbe14776c14d644c45",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/8eea230464783aa9671db8eea6f8c6ac5285794b",
+                "reference": "8eea230464783aa9671db8eea6f8c6ac5285794b",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -539,7 +541,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -563,9 +565,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.2"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.1"
             },
-            "time": "2024-09-17T19:36:00+00:00"
+            "time": "2024-10-08T18:51:32+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",

--- a/src/Processing/Compilation/PhpVisitor/InlineBlocksVisitor.php
+++ b/src/Processing/Compilation/PhpVisitor/InlineBlocksVisitor.php
@@ -100,10 +100,10 @@ final class InlineBlocksVisitor extends NodeVisitorAbstract
                                 ]),
                             ],
                             'uses' => [
-                                new Node\Expr\ClosureUse(
+                                new Node\ClosureUse(
                                     new Node\Expr\Variable('context'),
                                 ),
-                                new Node\Expr\ClosureUse(
+                                new Node\ClosureUse(
                                     new Node\Expr\Variable('blocks'),
                                 ),
                             ],

--- a/src/Processing/Compilation/PhpVisitor/RefactorLoopClosureVisitor.php
+++ b/src/Processing/Compilation/PhpVisitor/RefactorLoopClosureVisitor.php
@@ -70,7 +70,7 @@ final class RefactorLoopClosureVisitor extends NodeVisitorAbstract
         $closure->params[1]->var->name = '__context';
         $closure->params[1]->byRef = false;
 
-        $closure->uses[] = new Node\Expr\ClosureUse(new Variable('context'), true);
+        $closure->uses[] = new Node\ClosureUse(new Variable('context'), true);
 
         return $node;
     }

--- a/src/Processing/Compilation/PhpVisitor/RemoveBlockMethodsVisitor.php
+++ b/src/Processing/Compilation/PhpVisitor/RemoveBlockMethodsVisitor.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace TwigStan\Processing\Compilation\PhpVisitor;
 
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 
 final class RemoveBlockMethodsVisitor extends NodeVisitorAbstract
@@ -20,6 +20,6 @@ final class RemoveBlockMethodsVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        return NodeTraverser::REMOVE_NODE;
+        return NodeVisitor::REMOVE_NODE;
     }
 }

--- a/src/Processing/Compilation/PhpVisitor/RemoveImportMacroVisitor.php
+++ b/src/Processing/Compilation/PhpVisitor/RemoveImportMacroVisitor.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace TwigStan\Processing\Compilation\PhpVisitor;
 
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 
 final class RemoveImportMacroVisitor extends NodeVisitorAbstract
@@ -37,6 +37,6 @@ final class RemoveImportMacroVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        return NodeTraverser::REMOVE_NODE;
+        return NodeVisitor::REMOVE_NODE;
     }
 }

--- a/src/Processing/Compilation/PhpVisitor/RemoveImportsVisitor.php
+++ b/src/Processing/Compilation/PhpVisitor/RemoveImportsVisitor.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace TwigStan\Processing\Compilation\PhpVisitor;
 
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 
 final class RemoveImportsVisitor extends NodeVisitorAbstract
@@ -16,6 +16,6 @@ final class RemoveImportsVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        return NodeTraverser::REMOVE_NODE;
+        return NodeVisitor::REMOVE_NODE;
     }
 }

--- a/src/Processing/Compilation/PhpVisitor/RemoveParentYieldVisitor.php
+++ b/src/Processing/Compilation/PhpVisitor/RemoveParentYieldVisitor.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace TwigStan\Processing\Compilation\PhpVisitor;
 
 use PhpParser\Node;
-use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor;
 use PhpParser\NodeVisitorAbstract;
 
 final class RemoveParentYieldVisitor extends NodeVisitorAbstract
@@ -55,6 +55,6 @@ final class RemoveParentYieldVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        return NodeTraverser::REMOVE_NODE;
+        return NodeVisitor::REMOVE_NODE;
     }
 }

--- a/src/Processing/Compilation/PhpVisitor/ReplaceWithSimplifiedTwigTemplateVisitor.php
+++ b/src/Processing/Compilation/PhpVisitor/ReplaceWithSimplifiedTwigTemplateVisitor.php
@@ -6,6 +6,7 @@ namespace TwigStan\Processing\Compilation\PhpVisitor;
 
 use PhpParser\Builder\Class_;
 use PhpParser\Comment\Doc;
+use PhpParser\Modifiers;
 use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use TwigStan\Processing\Compilation\TwigGlobalsToPhpDoc;
@@ -83,7 +84,7 @@ final class ReplaceWithSimplifiedTwigTemplateVisitor extends NodeVisitorAbstract
                         ),
                     ];
                     $node->returnType = new Node\Identifier('iterable');
-                    $node->flags = ($node->flags & ~Node\Stmt\Class_::MODIFIER_PROTECTED) | Node\Stmt\Class_::MODIFIER_PUBLIC;
+                    $node->flags = ($node->flags & ~Modifiers::PROTECTED) | Modifiers::PUBLIC;
 
                     $node->stmts = [
                         // Add: $context = array_merge($__twigstan_globals, $context);
@@ -129,7 +130,7 @@ final class ReplaceWithSimplifiedTwigTemplateVisitor extends NodeVisitorAbstract
                         ),
                     ];
                     $node->returnType = new Node\Identifier('iterable');
-                    $node->flags = ($node->flags & ~Node\Stmt\Class_::MODIFIER_PROTECTED) | Node\Stmt\Class_::MODIFIER_PUBLIC;
+                    $node->flags = ($node->flags & ~Modifiers::PROTECTED) | Modifiers::PUBLIC;
 
                     return $node;
                 }

--- a/src/Processing/Flattening/PhpVisitor/InlineParentTemplateVisitor.php
+++ b/src/Processing/Flattening/PhpVisitor/InlineParentTemplateVisitor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TwigStan\Processing\Flattening\PhpVisitor;
 
+use LogicException;
 use PhpParser\Node;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitorAbstract;
@@ -29,12 +30,11 @@ final class InlineParentTemplateVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        $node = $node->expr;
-        if ( ! $node instanceof Node\Expr\YieldFrom) {
+        if ( ! $node->expr instanceof Node\Expr\YieldFrom) {
             return null;
         }
 
-        $expr = $node->expr;
+        $expr = $node->expr->expr;
         if ( ! $expr instanceof Node\Expr\MethodCall) {
             return null;
         }
@@ -54,8 +54,7 @@ final class InlineParentTemplateVisitor extends NodeVisitorAbstract
         $sourceLocation = CommentHelper::getSourceLocationFromComments($node->getComments());
 
         if ($sourceLocation === null) {
-            // @todo how to handle?
-            return null;
+            throw new LogicException('Expected source location to be set.');
         }
 
         $traverser = new NodeTraverser();

--- a/src/Processing/ScopeInjection/PhpVisitor/PhpToTemplateLinesNodeVisitor.php
+++ b/src/Processing/ScopeInjection/PhpVisitor/PhpToTemplateLinesNodeVisitor.php
@@ -45,7 +45,7 @@ final class PhpToTemplateLinesNodeVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        $this->mapping[$node->getLine()] = $sourceLocation;
+        $this->mapping[$node->getStartLine()] = $sourceLocation;
 
         return null;
     }


### PR DESCRIPTION
Fixes #62

Before, we had to use PHP Parser 4 because the project was set up as a PHPStan extension.

Since the architecture changed, we can freely change this to whatever version we want. 

