### PR TITLE
Unset _parent variable after for loop in Twig 3

### DIFF
--- a/castor.php
+++ b/castor.php
@@ -38,7 +38,7 @@ function phpstan(
         composer_install();
     }
 
-    return exit_code(['vendor/bin/phpstan', ...$rawTokens]);
+    return exit_code(['vendor/bin/phpstan', '--ansi', ...$rawTokens]);
 }
 
 #[AsTask(name: 'php-cs-fixer', aliases: ['code-style', 'cs'])]

--- a/src/Processing/Compilation/PhpVisitor/UnsetParentAfterForLoopVisitor.php
+++ b/src/Processing/Compilation/PhpVisitor/UnsetParentAfterForLoopVisitor.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\Processing\Compilation\PhpVisitor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+
+final class UnsetParentAfterForLoopVisitor extends NodeVisitorAbstract
+{
+    /**
+     * @return null|array<Node\Stmt>
+     */
+    public function leaveNode(Node $node): ?array
+    {
+        // Find: $_parent = $context['_parent'];
+        // Replace: $_parent = $context['_parent']; unset($context['_parent']);
+
+        if ( ! $node instanceof Node\Stmt\Expression) {
+            return null;
+        }
+
+        if ( ! $node->expr instanceof Node\Expr\Assign) {
+            return null;
+        }
+
+        if ( ! $node->expr->var instanceof Node\Expr\Variable) {
+            return null;
+        }
+
+        if ( ! is_string($node->expr->var->name)) {
+            return null;
+        }
+
+        if ($node->expr->var->name !== '_parent') {
+            return null;
+        }
+
+        if ( ! $node->expr->expr instanceof Node\Expr\ArrayDimFetch) {
+            return null;
+        }
+
+        if ( ! $node->expr->expr->var instanceof Node\Expr\Variable) {
+            return null;
+        }
+
+        if ($node->expr->expr->var->name !== 'context') {
+            return null;
+        }
+
+        if ( ! $node->expr->expr->dim instanceof Node\Scalar\String_) {
+            return null;
+        }
+
+        if ($node->expr->expr->dim->value !== '_parent') {
+            return null;
+        }
+
+        return [
+            $node,
+            new Node\Stmt\Unset_([
+                new Node\Expr\ArrayDimFetch(
+                    new Node\Expr\Variable('context'),
+                    new Node\Scalar\String_('_parent'),
+                ),
+            ]),
+        ];
+    }
+}

--- a/src/Processing/Compilation/TwigCompiler.php
+++ b/src/Processing/Compilation/TwigCompiler.php
@@ -30,6 +30,7 @@ use TwigStan\Processing\Compilation\PhpVisitor\RemoveParentYieldVisitor;
 use TwigStan\Processing\Compilation\PhpVisitor\RemoveUnwrapVisitor;
 use TwigStan\Processing\Compilation\PhpVisitor\ReplaceExtensionsArrayDimFetchToMethodCallVisitor;
 use TwigStan\Processing\Compilation\PhpVisitor\ReplaceWithSimplifiedTwigTemplateVisitor;
+use TwigStan\Processing\Compilation\PhpVisitor\UnsetParentAfterForLoopVisitor;
 
 final readonly class TwigCompiler
 {
@@ -81,6 +82,7 @@ final readonly class TwigCompiler
             new RemoveParentUnsetVisitor(),
             new IgnoreArgumentTemplateTypeOnEnsureTraversableVisitor(),
             new ReplaceExtensionsArrayDimFetchToMethodCallVisitor(),
+            ...(Environment::MAJOR_VERSION === 3 ? [new UnsetParentAfterForLoopVisitor()] : []),
             ...(Environment::MAJOR_VERSION >= 4 ? [new RefactorLoopClosureVisitor()] : []),
         );
 


### PR DESCRIPTION
Until we have https://github.com/twigphp/Twig/pull/4404, we need to manually unset the _parent variable
when the for loop finishes.

Otherwise PHPStan spends a lot of time analyzing loop in loops.

See https://github.com/phpstan/phpstan/issues/11890
