### PR TITLE
Use canonicalized Twig filename in Baseline

### DIFF
--- a/config/application.neon
+++ b/config/application.neon
@@ -7,6 +7,8 @@ services:
 		environmentLoader: %twigEnvironmentLoader%
 		tempDirectory: %tempDir%
 		currentWorkingDirectory: %currentWorkingDirectory%
+		configurationFile: %configurationFile%
+		baselineFile: %baselineFile%
 		phpFilesFinder: TwigStan\Finder\FilesFinder(
 			namePattern: *.php
 			paths: %phpPaths%

--- a/src/Application/AnalyzeCommand.php
+++ b/src/Application/AnalyzeCommand.php
@@ -406,18 +406,13 @@ final class AnalyzeCommand extends Command
                     continue;
                 }
 
-                if ($error->sourceLocation === null) {
-                    throw new LogicException('Error without source location should not be present here');
+                if ($error->twigFile === null) {
+                    throw new LogicException('Error without twigFile should not be present here');
                 }
 
                 $errorsCount++;
 
-                $twigFilePath = Path::makeRelative(
-                    $compilationResults->getByTwigFileName($error->sourceLocation->fileName)->twigFilePath,
-                    $this->currentWorkingDirectory,
-                );
-
-                $key = $error->message . "\n" . $error->identifier . "\n" . $twigFilePath;
+                $key = $error->message . "\n" . $error->identifier . "\n" . $error->twigFile;
 
                 if (array_key_exists($key, $baselineErrors)) {
                     $baselineErrors[$key]->increaseCount();
@@ -428,12 +423,12 @@ final class AnalyzeCommand extends Command
                 $baselineErrors[$key] = new BaselineError(
                     $error->message,
                     $error->identifier,
-                    $twigFilePath,
+                    $error->twigFile,
                     1,
                 );
             }
 
-            $dumper = new PhpBaselineDumper($this->currentWorkingDirectory);
+            $dumper = new PhpBaselineDumper();
 
             $this->filesystem->dumpFile(
                 $generateBaselineFile,

--- a/src/Config/ConfigBuilder.php
+++ b/src/Config/ConfigBuilder.php
@@ -81,6 +81,10 @@ final class ConfigBuilder
 
             // When the variable that is passed does not exist, this produces an error.
             IgnoreError::messageAndIdentifier('#CoreExtension::ensureTraversable#', 'argument.templateType'),
+
+            // When the context has an array that is untyped, this produces an error.
+            IgnoreError::messageAndIdentifier('#Method __TwigTemplate_\w+::\w+\(\) has parameter#', 'missingType.iterableValue'),
+            IgnoreError::messageAndIdentifier('#Method __TwigTemplate_\w+::\w+\(\) has parameter#', 'missingType.generics'),
         ];
     }
 

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -15,14 +15,13 @@ use TwigStan\Config\TwigStanConfig;
 final readonly class ContainerFactory
 {
     private string $rootDirectory;
-    private string $currentWorkingDirectory;
 
     public function __construct(
-        string $currentWorkingDirectory,
+        private string $currentWorkingDirectory,
+        private string $configurationFile,
         private TwigStanConfig $configuration,
     ) {
         $this->rootDirectory = Path::canonicalize(dirname(__DIR__, 2));
-        $this->currentWorkingDirectory = $currentWorkingDirectory;
     }
 
     public static function fromFile(string $currentWorkingDirectory, string $configurationFile): self
@@ -37,7 +36,7 @@ final readonly class ContainerFactory
             throw new InvalidArgumentException(sprintf("Configuration file \"%s\" must return an instance of %s.\n", $configurationFile, TwigStanConfig::class));
         }
 
-        return new self($currentWorkingDirectory, $configuration);
+        return new self($currentWorkingDirectory, $configurationFile, $configuration);
     }
 
     public function create(): Container
@@ -49,6 +48,7 @@ final readonly class ContainerFactory
             'debugMode' => true,
             'rootDir' => $this->rootDirectory,
             'currentWorkingDirectory' => $this->currentWorkingDirectory,
+            'configurationFile' => $this->configurationFile,
             'tempDirectory' => $this->configuration->tempDirectory,
             'baselineErrors' => $this->configuration->baselineErrors,
             'baselineFile' => $this->configuration->baselineFile,

--- a/src/Error/Baseline/PhpBaselineDumper.php
+++ b/src/Error/Baseline/PhpBaselineDumper.php
@@ -4,14 +4,8 @@ declare(strict_types=1);
 
 namespace TwigStan\Error\Baseline;
 
-use Symfony\Component\Filesystem\Path;
-
 final readonly class PhpBaselineDumper implements BaselineDumper
 {
-    public function __construct(
-        private string $currentWorkingDirectory,
-    ) {}
-
     public function dump(array $errors, string $baselineDirectory): string
     {
         $output = "<?php\n\n";
@@ -30,14 +24,8 @@ final readonly class PhpBaselineDumper implements BaselineDumper
                 $error->identifier === null ? 'null' : var_export($error->identifier, true),
             );
             $output .= sprintf(
-                "        __DIR__ . %s,\n",
-                var_export(Path::join(
-                    DIRECTORY_SEPARATOR,
-                    Path::makeRelative(
-                        Path::makeAbsolute($error->path, $this->currentWorkingDirectory),
-                        $baselineDirectory,
-                    ),
-                ), true),
+                "        %s,\n",
+                var_export($error->file, true),
             );
             $output .= sprintf(
                 "        %s,\n",

--- a/src/Error/Baseline/PhpBaselineDumper.php
+++ b/src/Error/Baseline/PhpBaselineDumper.php
@@ -14,13 +14,13 @@ final readonly class PhpBaselineDumper implements BaselineDumper
 
     public function dump(array $errors, string $baselineDirectory): string
     {
-        $output = "<?php\n\ndeclare(strict_types=1);\n\nreturn [\n";
+        $output = "<?php\n\n";
+        $output .= "declare(strict_types=1);\n\n";
+        $output .= "use TwigStan\Error\BaselineError;\n\n";
+        $output .= "return [\n";
 
         foreach ($errors as $error) {
-            $output .= sprintf(
-                "    new %s(\n",
-                $error::class,
-            );
+            $output .= "    new BaselineError(\n";
             $output .= sprintf(
                 "        %s,\n",
                 var_export($error->message, true),

--- a/src/Error/BaselineError.php
+++ b/src/Error/BaselineError.php
@@ -12,7 +12,7 @@ final class BaselineError implements Stringable
     public function __construct(
         public string $message,
         public ?string $identifier,
-        public string $path,
+        public string $file,
         public int $count = 1,
         public int $hits = 0,
     ) {}
@@ -36,7 +36,7 @@ final class BaselineError implements Stringable
             return false;
         }
 
-        if ($this->path === $error->sourceLocation->fileName) {
+        if ($this->file !== $error->twigFile) {
             return false;
         }
 
@@ -56,6 +56,6 @@ final class BaselineError implements Stringable
             $message = sprintf('%s (%s)', $message, $this->identifier);
         }
 
-        return sprintf('%s in path %s', $message, $this->path);
+        return sprintf('%s in file %s', $message, $this->file);
     }
 }

--- a/src/Error/BaselineErrorFilter.php
+++ b/src/Error/BaselineErrorFilter.php
@@ -47,7 +47,7 @@ final readonly class BaselineErrorFilter
 
             $errors[] = new Error(
                 sprintf(
-                    "Baseline error is expected to occur %d %s, but occurred only %d %s.\n%s",
+                    "Baseline error is expected to occur %d %s, but occurred %d %s.\n%s",
                     $baselineError->count,
                     $baselineError->count === 1 ? 'time' : 'times',
                     $baselineError->hits,

--- a/src/Processing/Compilation/PhpVisitor/ReplaceWithSimplifiedTwigTemplateVisitor.php
+++ b/src/Processing/Compilation/PhpVisitor/ReplaceWithSimplifiedTwigTemplateVisitor.php
@@ -60,7 +60,6 @@ final class ReplaceWithSimplifiedTwigTemplateVisitor extends NodeVisitorAbstract
                                  * @param array{} $context
                                  * @param array{} $blocks
                                  * @return iterable<null|scalar|\Stringable>
-                                 * @phpstan-ignore missingType.iterableValue
                                  */
                                 DOC,
                             $this->twigGlobalsToPhpDoc->getGlobals(),
@@ -120,7 +119,6 @@ final class ReplaceWithSimplifiedTwigTemplateVisitor extends NodeVisitorAbstract
                             /**
                              * @param array{} $context
                              * @return iterable<null|scalar|\Stringable>
-                             * @phpstan-ignore missingType.iterableValue
                              */
                             DOC,
                     ));

--- a/tests/Baseline/baseline.php
+++ b/tests/Baseline/baseline.php
@@ -2,29 +2,31 @@
 
 declare(strict_types=1);
 
+use TwigStan\Error\BaselineError;
+
 return [
-    new TwigStan\Error\BaselineError(
+    new BaselineError(
         'If condition is always false.',
         'if.alwaysFalse',
-        __DIR__ . '/homepage.html.twig',
+        '@__main__/Baseline/homepage.html.twig',
         1,
     ),
-    new TwigStan\Error\BaselineError(
+    new BaselineError(
         'Variable \'name\' does not exist.',
         'offsetAccess.notFound',
-        __DIR__ . '/layout.html.twig',
+        '@__main__/Baseline/layout.html.twig',
         3,
     ),
-    new TwigStan\Error\BaselineError(
+    new BaselineError(
         'Variable \'email\' does not exist.',
         'offsetAccess.notFound',
-        __DIR__ . '/layout.html.twig',
+        '@__main__/Baseline/layout.html.twig',
         2,
     ),
-    new TwigStan\Error\BaselineError(
+    new BaselineError(
         'Variable \'userId\' does not exist.',
         'offsetAccess.notFound',
-        __DIR__ . '/layout.html.twig',
+        '@__main__/Baseline/layout.html.twig',
         1,
     ),
 ];

--- a/tests/Baseline/expected.php
+++ b/tests/Baseline/expected.php
@@ -2,29 +2,31 @@
 
 declare(strict_types=1);
 
+use TwigStan\Error\BaselineError;
+
 return [
-    new TwigStan\Error\BaselineError(
+    new BaselineError(
         'If condition is always false.',
         'if.alwaysFalse',
-        __DIR__ . '/homepage.html.twig',
+        '@__main__/Baseline/homepage.html.twig',
         1,
     ),
-    new TwigStan\Error\BaselineError(
+    new BaselineError(
         'Variable \'name\' does not exist.',
         'offsetAccess.notFound',
-        __DIR__ . '/layout.html.twig',
+        '@__main__/Baseline/layout.html.twig',
         3,
     ),
-    new TwigStan\Error\BaselineError(
+    new BaselineError(
         'Variable \'email\' does not exist.',
         'offsetAccess.notFound',
-        __DIR__ . '/layout.html.twig',
+        '@__main__/Baseline/layout.html.twig',
         2,
     ),
-    new TwigStan\Error\BaselineError(
+    new BaselineError(
         'Variable \'userId\' does not exist.',
         'offsetAccess.notFound',
-        __DIR__ . '/layout.html.twig',
+        '@__main__/Baseline/layout.html.twig',
         1,
     ),
 ];


### PR DESCRIPTION
### Improve error message

### Ignore missing iterable + generics type in context

### Import FQCN in dumped baseline

### Use canonicalized Twig filename in Baseline

By storing the canonicalized filename we easily compare it against the reported error.

### Give hint on how to enable the baseline
