### PR TITLE
Update twig-loader-symfony.php

### DIFF
--- a/example/twig-loader-symfony.php
+++ b/example/twig-loader-symfony.php
@@ -7,7 +7,7 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require __DIR__ . '/vendor/autoload.php';
 
-(new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');
+(new Dotenv())->bootEnv(__DIR__ . '/.env');
 
 $kernel = new Kernel('test', true);
 $kernel->boot();


### PR DESCRIPTION
Isn't more classic to have 
__DIR__
- src
- vendor
- .env

So in the same way we require `__DIR__ . '/vendor/autoload.php'` we should access `__DIR__ . '/.env'.