### PR TITLE
Set globals as initial context

### DIFF
--- a/src/Config/ConfigBuilder.php
+++ b/src/Config/ConfigBuilder.php
@@ -82,6 +82,9 @@ final class ConfigBuilder
             // It's perfectly fine to do `if(var)` in Twig.
             IgnoreError::identifier('if.condNotBoolean'),
 
+            // It's perfectly fine to do `var ?: default` in Twig.
+            IgnoreError::identifier('ternary.shortNotAllowed'),
+
             // The context is backed up before a loop and restored after it.
             // Therefore this is a non-issue in Twig templates.
             IgnoreError::identifier('foreach.valueOverwrite'),

--- a/src/PHPStan/Collector/BlockContextCollector.php
+++ b/src/PHPStan/Collector/BlockContextCollector.php
@@ -76,7 +76,7 @@ final readonly class BlockContextCollector implements Collector, ExportingCollec
         return [
             'blockName' => $blockName,
             'sourceLocation' => $sourceLocation,
-            'context' => (new Printer())->print($context->toPhpDocNode()), // or this?: $context->describe(VerbosityLevel::cache()),
+            'context' => (new Printer())->print($context->toPhpDocNode()),
             'parent' => $node->expr->name->name === 'yieldParentBlock',
         ];
     }

--- a/src/Processing/Compilation/TwigGlobalsToPhpDoc.php
+++ b/src/Processing/Compilation/TwigGlobalsToPhpDoc.php
@@ -8,23 +8,20 @@ use PHPStan\PhpDocParser\Ast\ConstExpr\ConstExprStringNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeItemNode;
 use PHPStan\PhpDocParser\Ast\Type\ArrayShapeNode;
 use PHPStan\PhpDocParser\Ast\Type\IdentifierTypeNode;
-use PHPStan\PhpDocParser\Printer\Printer;
 use Twig\Environment;
 
 final class TwigGlobalsToPhpDoc
 {
-    private string $globals;
+    private ArrayShapeNode $globals;
 
     public function __construct(private Environment $twig) {}
 
-    public function getGlobals(): string
+    public function getGlobals(): ArrayShapeNode
     {
-        $this->globals ??= $this->generateGlobals();
-
-        return $this->globals;
+        return $this->globals ??= $this->generateGlobals();
     }
 
-    private function generateGlobals(): string
+    private function generateGlobals(): ArrayShapeNode
     {
         $globals = [];
         foreach ($this->twig->getGlobals() as $name => $value) {
@@ -41,8 +38,6 @@ final class TwigGlobalsToPhpDoc
             );
         }
 
-        $node = new ArrayShapeNode($globals);
-
-        return (new Printer())->print($node);
+        return new ArrayShapeNode($globals);
     }
 }

--- a/src/Processing/ScopeInjection/PhpVisitor/InjectContextVisitor.php
+++ b/src/Processing/ScopeInjection/PhpVisitor/InjectContextVisitor.php
@@ -54,24 +54,27 @@ final class InjectContextVisitor extends NodeVisitorAbstract
                 $match['parent'] !== '',
             );
 
-            $context = $this->arrayShapeMerger->merge(
-                $this->contextFromTemplateRender,
-                $contextBeforeBlock,
-                true,
-            );
+            $context = $contextBeforeBlock;
         } elseif ($node->name->name === 'main') {
             $context = $this->contextFromTemplateRender;
         } else {
             return null;
         }
 
-        $node->setDocComment(new Doc(
-            str_replace(
-                'array{} $context',
-                sprintf('%s $context', (new Printer())->print($context)),
-                $phpDoc->getText(),
+        $node->setDocComment(
+            new Doc(
+                sprintf(
+                    <<<'DOC'
+                        /**
+                         * @param %s $context
+                         * @param array{} $blocks
+                         * @return iterable<null|scalar|\Stringable>
+                         */
+                        DOC,
+                    (new Printer())->print($context),
+                ),
             ),
-        ));
+        );
 
         return $node;
     }

--- a/src/Processing/ScopeInjection/TwigScopeInjector.php
+++ b/src/Processing/ScopeInjection/TwigScopeInjector.php
@@ -23,6 +23,7 @@ use TwigStan\PHP\StrictPhpParser;
 use TwigStan\PHPStan\Analysis\CollectedData;
 use TwigStan\PHPStan\Collector\BlockContextCollector;
 use TwigStan\PHPStan\Collector\TemplateContextCollector;
+use TwigStan\Processing\Compilation\TwigGlobalsToPhpDoc;
 use TwigStan\Processing\Flattening\FlatteningResultCollection;
 use TwigStan\Processing\ScopeInjection\PhpVisitor\InjectContextVisitor;
 use TwigStan\Processing\ScopeInjection\PhpVisitor\PhpToTemplateLinesNodeVisitor;
@@ -38,6 +39,7 @@ final readonly class TwigScopeInjector
         private StrictPhpParser $phpParser,
         private ArrayShapeMerger $arrayShapeMerger,
         private TwigFileCanonicalizer $twigFileCanonicalizer,
+        private TwigGlobalsToPhpDoc $twigGlobalsToPhpDoc,
     ) {}
 
     /**
@@ -143,7 +145,11 @@ final readonly class TwigScopeInjector
                 $this->phpParser->parseFile($flatteningResult->phpFile),
                 new NameResolver(),
                 new InjectContextVisitor(
-                    $templateRenderContext[$flatteningResult->twigFileName] ?? new ArrayShapeNode([]),
+                    $this->arrayShapeMerger->merge(
+                        $this->twigGlobalsToPhpDoc->getGlobals(),
+                        $templateRenderContext[$flatteningResult->twigFileName] ?? new ArrayShapeNode([]),
+                        true,
+                    ),
                     $contextBeforeBlockRelatedToTemplate,
                     $this->arrayShapeMerger,
                 ),

--- a/tests/EndToEnd/Globals/GlobalsTest.php
+++ b/tests/EndToEnd/Globals/GlobalsTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\EndToEnd\Globals;
+
+use TwigStan\EndToEnd\AbstractEndToEndTestCase;
+
+final class GlobalsTest extends AbstractEndToEndTestCase
+{
+    public function test(): void
+    {
+        parent::runTests(__DIR__);
+    }
+}

--- a/tests/EndToEnd/Globals/errors.json
+++ b/tests/EndToEnd/Globals/errors.json
@@ -1,0 +1,4 @@
+{
+    "errors": [],
+    "fileSpecificErrors": []
+}

--- a/tests/EndToEnd/Globals/globals.twig
+++ b/tests/EndToEnd/Globals/globals.twig
@@ -1,0 +1,5 @@
+{% assert_type app "Symfony\\Bridge\\Twig\\AppVariable" %}
+
+{% block main %}
+    {% assert_type app "Symfony\\Bridge\\Twig\\AppVariable" %}
+{% endblock %}

--- a/tests/EndToEnd/Globals/override.twig
+++ b/tests/EndToEnd/Globals/override.twig
@@ -1,0 +1,7 @@
+{% assert_type app "Symfony\\Bridge\\Twig\\AppVariable" %}
+
+{% set app = false %}
+
+{% block main %}
+    {% assert_type app "false" %}
+{% endblock %}

--- a/tests/twig-loader.php
+++ b/tests/twig-loader.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Symfony\Bridge\Twig\AppVariable;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -9,4 +10,7 @@ $loader = new FilesystemLoader(rootPath: __DIR__);
 $loader->addPath(__DIR__);
 $loader->addPath(__DIR__ . '/EndToEnd', 'EndToEnd');
 
-return new Environment($loader);
+$environment = new Environment($loader);
+$environment->addGlobal('app', new AppVariable());
+
+return $environment;


### PR DESCRIPTION
### Ignore short ternary errors

### Remove comment

### Set globals as initial context

This way, we don't have to create a special `$__twigstan_globals` variable.
