### PR TITLE
Enable phpstan-todo-by issue tracker

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
                 uses: ramsey/composer-install@v3
 
             -   name: Run PHPStan
-                run: castor phpstan
+                run: castor phpstan --no-local
 
     composer:
         runs-on: ubuntu-latest

--- a/castor.php
+++ b/castor.php
@@ -29,16 +29,20 @@ function phpunit(
     return exit_code(['vendor/bin/phpunit', ...$rawTokens]);
 }
 
-#[AsTask(name: 'phpstan', aliases: ['stan'], ignoreValidationErrors: true)]
+#[AsTask(name: 'phpstan', aliases: ['stan'])]
 function phpstan(
-    #[AsRawTokens]
-    array $rawTokens = [],
+    #[AsOption(mode: InputOption::VALUE_NEGATABLE)]
+    bool $local = true,
 ): int {
     if ( ! fs()->exists('vendor')) {
         composer_install();
     }
 
-    return exit_code(['vendor/bin/phpstan', '--ansi', ...$rawTokens]);
+    return exit_code([
+        'vendor/bin/phpstan',
+        '--ansi',
+        sprintf('--configuration=%s', $local ? 'phpstan-local.neon' : 'phpstan.neon'),
+    ]);
 }
 
 #[AsTask(name: 'php-cs-fixer', aliases: ['code-style', 'cs', 'fmt'])]

--- a/phpstan-local.neon
+++ b/phpstan-local.neon
@@ -1,0 +1,16 @@
+includes:
+	- phpstan.neon
+parameters:
+	todo_by:
+		ticket:
+			enabled: true
+			tracker: github
+services:
+	-
+		class: TwigStan\PHPStan\DynamicReturnType\TypeHintReturnType
+		tags:
+			- phpstan.functionParameterOutTypeExtension
+	-
+		class: TwigStan\PHPStan\DynamicReturnType\GetAttributeReturnType
+		tags:
+			- phpstan.broker.dynamicStaticMethodReturnTypeExtension

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -15,12 +15,3 @@ parameters:
 	dynamicConstantNames:
 		- Twig\Environment::MAJOR_VERSION
 		- Twig\Environment::VERSION_ID
-services:
-	-
-		class: TwigStan\PHPStan\DynamicReturnType\TypeHintReturnType
-		tags:
-			- phpstan.functionParameterOutTypeExtension
-	-
-		class: TwigStan\PHPStan\DynamicReturnType\GetAttributeReturnType
-		tags:
-			- phpstan.broker.dynamicStaticMethodReturnTypeExtension


### PR DESCRIPTION
But only enable this locally.

We don't want CI to fail on this unexpectedly.

https://github.com/staabm/phpstan-todo-by?tab=readme-ov-file#issue-tracker-key-support
