### PR TITLE
Switch back to deprecated include block

### DIFF
--- a/.twig-cs-fixer.php
+++ b/.twig-cs-fixer.php
@@ -2,10 +2,14 @@
 
 declare(strict_types=1);
 
+use TwigCsFixer\Rules\Function\IncludeFunctionRule;
+
 $ruleset = new TwigCsFixer\Ruleset\Ruleset();
 
 // You can start from a default standard
 $ruleset->addStandard(new TwigCsFixer\Standard\TwigCsFixer());
+
+$ruleset->removeRule(IncludeFunctionRule::class);
 
 $ruleset->overrideRule(new TwigCsFixer\Rules\Variable\VariableNameRule(TwigCsFixer\Rules\Variable\VariableNameRule::CAMEL_CASE));
 

--- a/tests/EndToEnd/Include/include_block.twig
+++ b/tests/EndToEnd/Include/include_block.twig
@@ -1,23 +1,23 @@
 {% set somethingInTheContext = true %}
 
-{{ include('@EndToEnd/Include/_footer.twig') }}
-{{ include('@EndToEnd/Include/_footer.twig', [], false) }}
-{{ include('@EndToEnd/Include/_footer.twig', { title: 'Hello, World!' }) }}
-{{ include('@EndToEnd/Include/_footer.twig', { title: 'Hello, World!' }, false) }}
+{% include '@EndToEnd/Include/_footer.twig' %}
+{% include '@EndToEnd/Include/_footer.twig' only %}
+{% include '@EndToEnd/Include/_footer.twig' with { title: 'Hello, World!' } %}
+{% include '@EndToEnd/Include/_footer.twig' with { title: 'Hello, World!' } only %}
 
-{{ include('@EndToEnd/Include/maybe-exists.twig', [], true, true) }}
-{{ include('@EndToEnd/Include/maybe-exists.twig', [], false, true) }}
-{{ include('@EndToEnd/Include/maybe-exists.twig', { title: 'Hello, World!' }, true, true) }}
-{{ include('@EndToEnd/Include/maybe-exists.twig', { title: 'Hello, World!' }, false, true) }}
+{% include '@EndToEnd/Include/maybe-exists.twig' ignore missing %}
+{% include '@EndToEnd/Include/maybe-exists.twig' ignore missing only %}
+{% include '@EndToEnd/Include/maybe-exists.twig' ignore missing with { title: 'Hello, World!' } %}
+{% include '@EndToEnd/Include/maybe-exists.twig' ignore missing with { title: 'Hello, World!' } only %}
 
-{{ include(['@EndToEnd/Include/maybe-exists.twig', '@EndToEnd/Include/_footer.twig']) }}
-{{ include(['@EndToEnd/Include/maybe-exists.twig', '@EndToEnd/Include/_footer.twig'], [], true, true) }}
+{% include ['@EndToEnd/Include/maybe-exists.twig', '@EndToEnd/Include/_footer.twig'] %}
+{% include ['@EndToEnd/Include/maybe-exists.twig', '@EndToEnd/Include/_footer.twig'] ignore missing %}
 
 {% set template = '@EndToEnd/Include/_footer.twig' %}
-{{ include(template) }}
+{% include template %}
 
 {% types {
     isMobile: 'bool'
 } %}
 
-{{ include(isMobile ? '@EndToEnd/Include/isMobile.twig' : '@EndToEnd/Include/_footer.twig') }}
+{% include isMobile ? '@EndToEnd/Include/isMobile.twig' : '@EndToEnd/Include/_footer.twig' %}


### PR DESCRIPTION
### Disable IncludeFunctionRule

### Switch back to deprecated include block

This was accidentally fixed by Twig CS Fixer.
