### PR TITLE
Convert Twig names to absolute paths everywhere

### DIFF
--- a/config/phpstan.analyze-twig-templates.neon
+++ b/config/phpstan.analyze-twig-templates.neon
@@ -6,6 +6,7 @@ services:
 		class: Twig\Environment
 		factory: @TwigStan\Twig\TwigFactory::create
 	- TwigStan\Processing\Compilation\Parser\TwigNodeParser
+	- TwigStan\Twig\TwigFileCanonicalizer
 	- TwigStan\Twig\TwigFactory(environmentLoader: %twigstan.twigEnvironmentLoader%)
 	- TwigStan\Twig\TokenParser\AssertTypeTokenParser
 	- TwigStan\Twig\TokenParser\AssertVariableExistsTokenParser

--- a/config/phpstan.collect-twig-render-points.neon
+++ b/config/phpstan.collect-twig-render-points.neon
@@ -10,6 +10,7 @@ services:
 		class: Twig\Environment
 		factory: @TwigStan\Twig\TwigFactory::create
 	- TwigStan\Processing\Compilation\Parser\TwigNodeParser
+	- TwigStan\Twig\TwigFileCanonicalizer
 	- TwigStan\Twig\TwigFactory(environmentLoader: %twigstan.twigEnvironmentLoader%)
 	- TwigStan\Twig\TokenParser\AssertTypeTokenParser
 	- TwigStan\Twig\TokenParser\AssertVariableExistsTokenParser

--- a/src/Processing/Compilation/CompilationResult.php
+++ b/src/Processing/Compilation/CompilationResult.php
@@ -7,7 +7,6 @@ namespace TwigStan\Processing\Compilation;
 final readonly class CompilationResult
 {
     public function __construct(
-        public string $twigFileName,
         public string $twigFilePath,
         public string $phpFile,
     ) {}

--- a/src/Processing/Compilation/CompilationResultCollection.php
+++ b/src/Processing/Compilation/CompilationResultCollection.php
@@ -24,7 +24,7 @@ final readonly class CompilationResultCollection implements IteratorAggregate
 
         $this->results = array_combine(
             array_map(
-                fn(CompilationResult $result) => $result->twigFileName,
+                fn(CompilationResult $result) => $result->twigFilePath,
                 $results,
             ),
             $results,
@@ -47,33 +47,6 @@ final readonly class CompilationResultCollection implements IteratorAggregate
     public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->results);
-    }
-
-    public function hasPhpFile(string $phpFile): bool
-    {
-        foreach ($this->results as $result) {
-            if ($result->phpFile === $phpFile) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    public function getByPhpFile(string $phpFile): CompilationResult
-    {
-        foreach ($this->results as $result) {
-            if ($result->phpFile === $phpFile) {
-                return $result;
-            }
-        }
-
-        throw new InvalidArgumentException(sprintf('No CompilationResult found for PHP file "%s".', $phpFile));
-    }
-
-    public function hasTwigFileName(string $fileName): bool
-    {
-        return isset($this->results[$fileName]);
     }
 
     public function getByTwigFileName(string $fileName): CompilationResult

--- a/src/Processing/Compilation/Parser/TwigNodeParser.php
+++ b/src/Processing/Compilation/Parser/TwigNodeParser.php
@@ -8,11 +8,13 @@ use Twig\Environment;
 use Twig\Error\LoaderError;
 use Twig\Error\SyntaxError;
 use Twig\Node\ModuleNode;
+use TwigStan\Twig\TwigFileCanonicalizer;
 
 final readonly class TwigNodeParser
 {
     public function __construct(
         private Environment $twig,
+        private TwigFileCanonicalizer $twigFileCanonicalizer,
     ) {}
 
     /**
@@ -24,6 +26,8 @@ final readonly class TwigNodeParser
         if ($template instanceof ModuleNode) {
             return $template;
         }
+
+        $template = $this->twigFileCanonicalizer->canonicalize($template);
 
         $source = $this->twig->getLoader()->getSourceContext($template);
 

--- a/src/Processing/Flattening/FlatteningResult.php
+++ b/src/Processing/Flattening/FlatteningResult.php
@@ -7,7 +7,6 @@ namespace TwigStan\Processing\Flattening;
 final readonly class FlatteningResult
 {
     public function __construct(
-        public string $twigFileName,
         public string $twigFilePath,
         public string $phpFile,
     ) {}

--- a/src/Processing/Flattening/FlatteningResultCollection.php
+++ b/src/Processing/Flattening/FlatteningResultCollection.php
@@ -24,7 +24,7 @@ final readonly class FlatteningResultCollection implements IteratorAggregate
 
         $this->results = array_combine(
             array_map(
-                fn(FlatteningResult $result) => $result->twigFileName,
+                fn(FlatteningResult $result) => $result->twigFilePath,
                 $results,
             ),
             $results,

--- a/src/Processing/Flattening/TwigFlattener.php
+++ b/src/Processing/Flattening/TwigFlattener.php
@@ -34,7 +34,7 @@ final readonly class TwigFlattener
     {
         $results = new FlatteningResultCollection();
         foreach ($collection as $compilationResult) {
-            $metadata = $this->metadataRegistry->getMetadata($compilationResult->twigFileName);
+            $metadata = $this->metadataRegistry->getMetadata($compilationResult->twigFilePath);
 
             if ($metadata->hasResolvableParents()) {
                 foreach ($metadata->parents as $parent) {
@@ -74,7 +74,7 @@ final readonly class TwigFlattener
                     $traverser->traverse($phpAst);
 
                     $sourceLocation = new SourceLocation(
-                        $metadata->name,
+                        $metadata->filePath,
                         $metadata->parentLineNumber ?? 0,
                     );
 
@@ -104,7 +104,6 @@ final readonly class TwigFlattener
                     );
 
                     $results = $results->with(new FlatteningResult(
-                        $compilationResult->twigFileName,
                         $compilationResult->twigFilePath,
                         $phpFile,
                     ));
@@ -120,7 +119,6 @@ final readonly class TwigFlattener
 
             $results = $results->with(
                 new FlatteningResult(
-                    $compilationResult->twigFileName,
                     $compilationResult->twigFilePath,
                     Path::join(
                         $targetDirectory,

--- a/src/Processing/ScopeInjection/ScopeInjectionResult.php
+++ b/src/Processing/ScopeInjection/ScopeInjectionResult.php
@@ -12,7 +12,6 @@ final readonly class ScopeInjectionResult
      * @param array<int, SourceLocation> $phpToTwigLineMapping
      */
     public function __construct(
-        public string $twigFileName,
         public string $twigFilePath,
         public string $phpFile,
         public array $phpToTwigLineMapping,

--- a/src/Processing/ScopeInjection/ScopeInjectionResultCollection.php
+++ b/src/Processing/ScopeInjection/ScopeInjectionResultCollection.php
@@ -24,7 +24,7 @@ final readonly class ScopeInjectionResultCollection implements IteratorAggregate
 
         $this->results = array_combine(
             array_map(
-                fn(ScopeInjectionResult $result) => $result->twigFileName,
+                fn(ScopeInjectionResult $result) => $result->twigFilePath,
                 $results,
             ),
             $results,

--- a/src/Processing/ScopeInjection/TwigScopeInjector.php
+++ b/src/Processing/ScopeInjection/TwigScopeInjector.php
@@ -80,7 +80,7 @@ final readonly class TwigScopeInjector
         foreach ($collection as $flatteningResult) {
             $contextBeforeBlockRelatedToTemplate = array_values(array_filter(
                 $contextBeforeBlock,
-                fn($contextBeforeBlock) => $contextBeforeBlock['sourceLocation']->contains($flatteningResult->twigFileName),
+                fn($contextBeforeBlock) => $contextBeforeBlock['sourceLocation']->contains($flatteningResult->twigFilePath),
             ));
             $stmts = $this->applyVisitors(
                 $this->phpParser->parseFile($flatteningResult->phpFile),
@@ -107,7 +107,6 @@ final readonly class TwigScopeInjector
             $this->applyVisitors($stmts, $visitor);
 
             $results = $results->with(new ScopeInjectionResult(
-                $flatteningResult->twigFileName,
                 $flatteningResult->twigFilePath,
                 $phpFile,
                 $visitor->getMapping(),

--- a/src/Twig/CommentHelper.php
+++ b/src/Twig/CommentHelper.php
@@ -16,15 +16,15 @@ final readonly class CommentHelper
 
         $comment = substr($comment, 8);
 
-        if (preg_match_all('#(?<name>[@\/\w.-]+):(?<line_number>\d+)#', $comment, $matches, PREG_SET_ORDER) === 0) {
-            return null;
-        }
+        $pairs = explode(', ', $comment);
 
         $sourceLocation = null;
-        foreach (array_reverse($matches) as $match) {
+        foreach (array_reverse($pairs) as $pair) {
+            [$fileName, $line] = explode(':', $pair);
+
             $sourceLocation = new SourceLocation(
-                $match['name'],
-                (int) $match['line_number'],
+                $fileName,
+                (int) $line,
                 $sourceLocation,
             );
         }

--- a/src/Twig/Metadata/MetadataAnalyzer.php
+++ b/src/Twig/Metadata/MetadataAnalyzer.php
@@ -43,7 +43,7 @@ final readonly class MetadataAnalyzer
         if ($template->hasNode('parent')) {
             $parentLineNumber = $template->getNode('parent')->getTemplateLine();
             $parents = array_map(
-                $this->twigFileCanonicalizer->canonicalize(...),
+                $this->twigFileCanonicalizer->absolute(...),
                 $this->getStringsFromExpression($template->getNode('parent')),
             );
         }
@@ -83,7 +83,7 @@ final readonly class MetadataAnalyzer
         foreach ([$template->getNode('body'), ...$template->getNode('blocks')] as $node) {
             foreach ($this->nodeFinder->findInstanceOf($node, ImportNode::class) as $importNode) {
                 $macros = [...$macros, ...array_map(
-                    $this->twigFileCanonicalizer->canonicalize(...),
+                    $this->twigFileCanonicalizer->absolute(...),
                     $this->getStringsFromExpression($importNode->getNode('expr')),
                 )];
             }

--- a/src/Twig/TwigFileCanonicalizer.php
+++ b/src/Twig/TwigFileCanonicalizer.php
@@ -23,6 +23,11 @@ final class TwigFileCanonicalizer
         private Environment $twig,
     ) {}
 
+    public function absolute(string $name): string
+    {
+        return $this->twig->getLoader()->getSourceContext($name)->getPath();
+    }
+
     /**
      * Takes a relative or absolute path and returns a canonicalized Twig path.
      *


### PR DESCRIPTION
Before, we would annotate the source code with canonicalized Twig names.
But this requires us to convert back and forth.

It would be easier to always work with absolute file names, same as for PHP.
