### PR TITLE
Require exact Twig versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+    -   package-ecosystem: composer
+        directory: "/"
+        open-pull-requests-limit: 20
+        schedule:
+            interval: daily
+            time: "06:00"
+            timezone: Europe/Amsterdam
+        rebase-strategy: disabled
+        allow:
+            -   dependency-name: "twig/twig"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/filesystem": "^7.1",
         "symfony/finder": "^7.1",
         "symfony/process": "^7.1",
-        "twig/twig": "^3.13"
+        "twig/twig": "3.14.2"
     },
     "require-dev": {
         "editorconfig-checker/editorconfig-checker": "^10.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e5e547e02d3d9b3a1aef9e471f900b2",
+    "content-hash": "a6489d991c3bf798ed4a8f1b2d2ce052",
     "packages": [
         {
             "name": "nette/bootstrap",

--- a/tests/EndToEnd/Filters/errors.json
+++ b/tests/EndToEnd/Filters/errors.json
@@ -1,12 +1,4 @@
 {
-    "errors": [
-        {
-            "message": "Parameter #1 $value of static method Twig\\Extension\\CoreExtension::join() expects array, string given.",
-            "identifier": "argument.type",
-            "tip": null,
-            "twigSourceLocation": "array.twig:4",
-            "renderPoints": []
-        }
-    ],
+    "errors": [],
     "fileSpecificErrors": []
 }

--- a/tests/EndToEnd/Filters/errors.v3.json
+++ b/tests/EndToEnd/Filters/errors.v3.json
@@ -1,0 +1,9 @@
+[
+    {
+        "message": "Parameter #1 $value of static method Twig\\Extension\\CoreExtension::join() expects array, string given.",
+        "identifier": "argument.type",
+        "tip": null,
+        "twigSourceLocation": "array.twig:4",
+        "renderPoints": []
+    }
+]


### PR DESCRIPTION
### Require exact Twig versions

Because TwigStan works with the compiled code of Twig, and the compiled code
is not part of any backwards compatibility promise, we need to pin to exact Twig versions.

If we don't, we cannot guarantee that TwigStan works as expected.

### Setup Dependabot for Twig

Since we pin to exact versions, we need to use Dependabot to update Twig.
