### PR TITLE
Remove ext-hash dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,6 @@
     ],
     "require": {
         "php": "^8.3",
-        "ext-hash": "*",
         "composer-runtime-api": "^2.2",
         "nette/bootstrap": "^3.2",
         "nette/di": "^3.2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e74bd8d1a44d7ae879ca4073eed3d5c",
+    "content-hash": "d109f37e547e1255d1024486df89b2ed",
     "packages": [
         {
             "name": "nette/bootstrap",
@@ -7866,7 +7866,6 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.3",
-        "ext-hash": "*",
         "composer-runtime-api": "^2.2"
     },
     "platform-dev": {},


### PR DESCRIPTION
This is part of core and therefore redundant.
