### PR TITLE
Fix type narrowing

### DIFF
--- a/src/Processing/Compilation/PhpVisitor/RemoveLineNumberFromGetAttributeCallVisitor.php
+++ b/src/Processing/Compilation/PhpVisitor/RemoveLineNumberFromGetAttributeCallVisitor.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\Processing\Compilation\PhpVisitor;
+
+use PhpParser\Node;
+use PhpParser\NodeVisitorAbstract;
+use Twig\Extension\CoreExtension;
+
+final class RemoveLineNumberFromGetAttributeCallVisitor extends NodeVisitorAbstract
+{
+    public function enterNode(Node $node): ?Node\Expr\StaticCall
+    {
+        if ( ! $node instanceof Node\Expr\StaticCall) {
+            return null;
+        }
+
+        if ( ! $node->class instanceof Node\Name\FullyQualified) {
+            return null;
+        }
+
+        if ($node->class->toString() !== CoreExtension::class) {
+            return null;
+        }
+
+        if ( ! $node->name instanceof Node\Identifier) {
+            return null;
+        }
+
+        if ($node->name->name !== 'getAttribute') {
+            return null;
+        }
+
+        if ( ! isset($node->args[9])) {
+            foreach ($node->args as $arg) {
+                if ( ! $arg instanceof Node\Arg) {
+                    continue;
+                }
+
+                if ( ! $arg->name instanceof Node\Identifier) {
+                    continue;
+                }
+
+                if ($arg->name->name !== 'lineno') {
+                    continue;
+                }
+
+                $arg->value = new Node\Scalar\Int_(0);
+
+                return $node;
+            }
+
+            return null;
+        }
+
+        if ( ! $node->args[9] instanceof Node\Arg) {
+            return null;
+        }
+
+        $node->args[9]->value = new Node\Scalar\Int_(0);
+
+        return $node;
+    }
+}

--- a/src/Processing/Compilation/TwigCompiler.php
+++ b/src/Processing/Compilation/TwigCompiler.php
@@ -25,6 +25,7 @@ use TwigStan\Processing\Compilation\PhpVisitor\MakeFinalVisitor;
 use TwigStan\Processing\Compilation\PhpVisitor\RefactorExtensionCallVisitor;
 use TwigStan\Processing\Compilation\PhpVisitor\RefactorLoopClosureVisitor;
 use TwigStan\Processing\Compilation\PhpVisitor\RemoveImportsVisitor;
+use TwigStan\Processing\Compilation\PhpVisitor\RemoveLineNumberFromGetAttributeCallVisitor;
 use TwigStan\Processing\TemplateContext;
 use TwigStan\Processing\TemplateContextToArrayShape;
 
@@ -75,6 +76,7 @@ final readonly class TwigCompiler
             new RemoveImportsVisitor(),
             new AddTypeCommentsToTemplateVisitor($this->templateContextToArrayShape->getByTemplate($templateContext, $twigFilePath)),
             new IgnoreArgumentTemplateTypeOnEnsureTraversableVisitor(),
+            new RemoveLineNumberFromGetAttributeCallVisitor(),
             new AddGetExtensionMethodVisitor(),
             new RefactorExtensionCallVisitor(),
             ...(Environment::MAJOR_VERSION >= 4 ? [new RefactorLoopClosureVisitor()] : []),

--- a/tests/EndToEnd/GetAttribute/narrowing.twig
+++ b/tests/EndToEnd/GetAttribute/narrowing.twig
@@ -1,0 +1,13 @@
+{% types {
+    user: 'TwigStan\\Fixtures\\User',
+} %}
+
+{% if user.lastPurchaseAt %}
+    {% assert_type user.lastPurchaseAt 'DateTimeImmutable' %}
+    {% assert_type user.lastPurchaseAt.format('Y-m-d') 'string' %}
+{% else %}
+    {% assert_type user.lastPurchaseAt 'null' %}
+    {% assert_type user.lastPurchaseAt.format('Y-m-d') '*ERROR*' %}
+{% endif %}
+
+{% assert_type user.lastPurchaseAt.format('Y-m-d') '*ERROR*' %}


### PR DESCRIPTION
Type narrowing was not possible because PHPStan would not cache calls to CoreExtension::getAttribute
because the last argument was the line number. This means the cache key always changes.
