### PR TITLE
Ignore error identifiers when source has previous location

### DIFF
--- a/src/Application/AnalyzeCommand.php
+++ b/src/Application/AnalyzeCommand.php
@@ -347,6 +347,62 @@ final class AnalyzeCommand extends Command
                 'function.alreadyNarrowedType',
                 'function.impossibleType',
             ]),
+            IgnoreError::identifier('isset.variable'),
+
+            // It's perfectly fine to do `a == b ? 'yes' : 'no'` in Twig.
+            IgnoreError::identifier('equal.notAllowed'),
+
+            // It's perfectly fine to do `a != b ? 'no' : 'yes'` in Twig.
+            IgnoreError::identifier('notEqual.notAllowed'),
+
+            // It's perfectly fine to do `if(var)` in Twig.
+            IgnoreError::identifier('if.condNotBoolean'),
+
+            IgnoreError::identifier('ternary.condNotBoolean'),
+
+            IgnoreError::identifier('booleanAnd.leftNotBoolean'),
+
+            // It's perfectly fine to do `var ?: default` in Twig.
+            IgnoreError::identifier('ternary.shortNotAllowed'),
+
+            // The context is backed up before a loop and restored after it.
+            // Therefore this is a non-issue in Twig templates.
+            IgnoreError::identifier('foreach.valueOverwrite'),
+
+            // These identifiers don't make sense for compiled Twig templates.
+            IgnoreError::identifier('missingType.checkedException'),
+            IgnoreError::identifier('missingType.parameter'),
+            IgnoreError::identifier('missingType.return'),
+            IgnoreError::identifier('method.missingOverride'),
+            IgnoreError::identifier('return.unusedType'),
+
+            // We cannot guarantee that a short arrow closure uses the context/macros/blocks variable.
+            IgnoreError::messageAndIdentifier('#Anonymous function has an unused use \$context\.#', 'closure.unusedUse'),
+            IgnoreError::messageAndIdentifier('#Anonymous function has an unused use \$macros\.#', 'closure.unusedUse'),
+            IgnoreError::messageAndIdentifier('#Anonymous function has an unused use \$blocks#', 'closure.unusedUse'),
+
+            // When the variable that is passed does not exist, this produces an error.
+            IgnoreError::messageAndIdentifier('#CoreExtension::ensureTraversable#', 'argument.templateType'),
+
+            // The context can contain anything, so we don't want to be strict here.
+            IgnoreError::messageAndIdentifier('#Method __TwigTemplate_\w+::\w+\(\) has parameter#', 'missingType.iterableValue'),
+            IgnoreError::messageAndIdentifier('#Method __TwigTemplate_\w+::\w+\(\) has parameter#', 'missingType.generics'),
+            IgnoreError::messageAndIdentifier('#Method __TwigTemplate_\w+::\w+\(\) has parameter#', 'parameter.deprecatedClass'),
+            IgnoreError::messageAndIdentifier('#Parameter \$context of method __TwigTemplate_\w+::\w+\(\) has typehint#', 'parameter.deprecatedClass'),
+
+            // We cannot guarantee that the property will be used in the compiled template.
+            IgnoreError::messageAndIdentifier('#Property __TwigTemplate_\w+::\$source is never read, only written\.#', 'property.onlyWritten'),
+
+            // This happens because the parent method accepts an array.
+            IgnoreError::messageAndIdentifier("#Parameter .* of method __TwigTemplate_\w+::doDisplay\(\) should be contravariant with parameter#", 'method.childParameterType'),
+
+            // Currently Dynamic Inheritance is not (yet) supported. Ignoring the errors for now.
+            // @see https://github.com/twigstan/twigstan/issues/6
+            IgnoreError::messageAndIdentifier('#Access to an undefined property __TwigTemplate_\w+::\$blocks\.#', 'property.notFound'),
+            IgnoreError::messageAndIdentifier('#Call to an undefined method __TwigTemplate_\w+::getParent\(\)\.#', 'method.notFound'),
+
+            // @see https://github.com/twigphp/Twig/pull/4415
+            IgnoreError::messageAndIdentifier('#Cannot call method unwrap\(\) on Twig\\\Template\|Twig\\\TemplateWrapper\|false\.#', 'method.nonObject'),
         ]))->filter($errors);
 
         foreach ($abstractTemplates as $abstractTemplate) {

--- a/src/Application/AnalyzeCommand.php
+++ b/src/Application/AnalyzeCommand.php
@@ -23,6 +23,7 @@ use TwigStan\Error\ErrorCollapser;
 use TwigStan\Error\ErrorFilter;
 use TwigStan\Error\ErrorToSourceFileMapper;
 use TwigStan\Error\ErrorTransformer;
+use TwigStan\Error\IgnoreByIdentifierWhenSourceLocationHasPrevious;
 use TwigStan\Error\IgnoreError;
 use TwigStan\Finder\FilesFinder;
 use TwigStan\Finder\GivenFilesFinder;
@@ -337,12 +338,16 @@ final class AnalyzeCommand extends Command
         // Ignore errors for abstract templates
         $abstractTemplates = $this->metadataRegistry->getAbstractTemplates();
 
-        $errors = (new ErrorFilter(
-            array_map(
+        $errors = (new ErrorFilter([
+            ...array_map(
                 fn($template) => IgnoreError::path($template),
                 $abstractTemplates,
             ),
-        ))->filter($errors);
+            new IgnoreByIdentifierWhenSourceLocationHasPrevious([
+                'function.alreadyNarrowedType',
+                'function.impossibleType',
+            ]),
+        ]))->filter($errors);
 
         foreach ($abstractTemplates as $abstractTemplate) {
             // We only want to error when an abstract template is rendered from PHP.

--- a/src/Config/ConfigBuilder.php
+++ b/src/Config/ConfigBuilder.php
@@ -63,7 +63,7 @@ final class ConfigBuilder
     /**
      * @var list<IgnoreError>
      */
-    private array $ignoreErrors;
+    private array $ignoreErrors = [];
 
     /**
      * @var list<BaselineError>
@@ -81,65 +81,6 @@ final class ConfigBuilder
         }
 
         $this->projectRootDirectory = $projectRootDirectory;
-
-        $this->ignoreErrors = [
-            IgnoreError::identifier('isset.variable'),
-
-            // It's perfectly fine to do `a == b ? 'yes' : 'no'` in Twig.
-            IgnoreError::identifier('equal.notAllowed'),
-
-            // It's perfectly fine to do `a != b ? 'no' : 'yes'` in Twig.
-            IgnoreError::identifier('notEqual.notAllowed'),
-
-            // It's perfectly fine to do `if(var)` in Twig.
-            IgnoreError::identifier('if.condNotBoolean'),
-
-            IgnoreError::identifier('ternary.condNotBoolean'),
-
-            IgnoreError::identifier('booleanAnd.leftNotBoolean'),
-
-            // It's perfectly fine to do `var ?: default` in Twig.
-            IgnoreError::identifier('ternary.shortNotAllowed'),
-
-            // The context is backed up before a loop and restored after it.
-            // Therefore this is a non-issue in Twig templates.
-            IgnoreError::identifier('foreach.valueOverwrite'),
-
-            // These identifiers don't make sense for compiled Twig templates.
-            IgnoreError::identifier('missingType.checkedException'),
-            IgnoreError::identifier('missingType.parameter'),
-            IgnoreError::identifier('missingType.return'),
-            IgnoreError::identifier('method.missingOverride'),
-            IgnoreError::identifier('return.unusedType'),
-
-            // We cannot guarantee that a short arrow closure uses the context/macros/blocks variable.
-            IgnoreError::messageAndIdentifier('#Anonymous function has an unused use \$context\.#', 'closure.unusedUse'),
-            IgnoreError::messageAndIdentifier('#Anonymous function has an unused use \$macros\.#', 'closure.unusedUse'),
-            IgnoreError::messageAndIdentifier('#Anonymous function has an unused use \$blocks#', 'closure.unusedUse'),
-
-            // When the variable that is passed does not exist, this produces an error.
-            IgnoreError::messageAndIdentifier('#CoreExtension::ensureTraversable#', 'argument.templateType'),
-
-            // The context can contain anything, so we don't want to be strict here.
-            IgnoreError::messageAndIdentifier('#Method __TwigTemplate_\w+::\w+\(\) has parameter#', 'missingType.iterableValue'),
-            IgnoreError::messageAndIdentifier('#Method __TwigTemplate_\w+::\w+\(\) has parameter#', 'missingType.generics'),
-            IgnoreError::messageAndIdentifier('#Method __TwigTemplate_\w+::\w+\(\) has parameter#', 'parameter.deprecatedClass'),
-            IgnoreError::messageAndIdentifier('#Parameter \$context of method __TwigTemplate_\w+::\w+\(\) has typehint#', 'parameter.deprecatedClass'),
-
-            // We cannot guarantee that the property will be used in the compiled template.
-            IgnoreError::messageAndIdentifier('#Property __TwigTemplate_\w+::\$source is never read, only written\.#', 'property.onlyWritten'),
-
-            // This happens because the parent method accepts an array.
-            IgnoreError::messageAndIdentifier("#Parameter .* of method __TwigTemplate_\w+::doDisplay\(\) should be contravariant with parameter#", 'method.childParameterType'),
-
-            // Currently Dynamic Inheritance is not (yet) supported. Ignoring the errors for now.
-            // @see https://github.com/twigstan/twigstan/issues/6
-            IgnoreError::messageAndIdentifier('#Access to an undefined property __TwigTemplate_\w+::\$blocks\.#', 'property.notFound'),
-            IgnoreError::messageAndIdentifier('#Call to an undefined method __TwigTemplate_\w+::getParent\(\)\.#', 'method.notFound'),
-
-            // @see https://github.com/twigphp/Twig/pull/4415
-            IgnoreError::messageAndIdentifier('#Cannot call method unwrap\(\) on Twig\\\Template\|Twig\\\TemplateWrapper\|false\.#', 'method.nonObject'),
-        ];
     }
 
     public static function extend(string $configurationFile): self

--- a/src/Error/ErrorFilter.php
+++ b/src/Error/ErrorFilter.php
@@ -9,7 +9,7 @@ use TwigStan\PHPStan\Analysis\Error;
 final readonly class ErrorFilter
 {
     /**
-     * @param list<IgnoreError> $ignoreErrors
+     * @param list<Ignorable> $ignoreErrors
      */
     public function __construct(private array $ignoreErrors) {}
 

--- a/src/Error/Ignorable.php
+++ b/src/Error/Ignorable.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\Error;
+
+use TwigStan\PHPStan\Analysis\Error;
+
+interface Ignorable
+{
+    public function shouldIgnore(Error $error): bool;
+}

--- a/src/Error/IgnoreByIdentifierWhenSourceLocationHasPrevious.php
+++ b/src/Error/IgnoreByIdentifierWhenSourceLocationHasPrevious.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TwigStan\Error;
+
+use TwigStan\PHPStan\Analysis\Error;
+
+final readonly class IgnoreByIdentifierWhenSourceLocationHasPrevious implements Ignorable
+{
+    /**
+     * @param list<string> $identifiers
+     */
+    public function __construct(private array $identifiers) {}
+
+    public function shouldIgnore(Error $error): bool
+    {
+        if ($error->sourceLocation?->previous === null) {
+            return false;
+        }
+
+        return in_array($error->identifier, $this->identifiers, true);
+    }
+}

--- a/src/Error/IgnoreError.php
+++ b/src/Error/IgnoreError.php
@@ -7,7 +7,7 @@ namespace TwigStan\Error;
 use InvalidArgumentException;
 use TwigStan\PHPStan\Analysis\Error;
 
-final class IgnoreError
+final class IgnoreError implements Ignorable
 {
     /**
      * @param null|string $path Path to Twig file or directory. This can contain wildcards.


### PR DESCRIPTION
This makes sure errors like below are ignored, when the template is extended:
> Call to function array_key_exists() with 'hideFooter' and array{ ... } will always evaluate to false.
